### PR TITLE
Rename consistency

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -958,8 +958,8 @@ typedef struct SDL_GPUViewport
     float y;
     float w;
     float h;
-    float minDepth;
-    float maxDepth;
+    float min_depth;
+    float max_depth;
 } SDL_GPUViewport;
 
 typedef struct SDL_GPUTextureTransferInfo
@@ -1126,7 +1126,7 @@ typedef struct SDL_GPUShaderCreateInfo
 {
     size_t code_size;
     const Uint8 *code;
-    const char *entrypoint_name;
+    const char *entrypoint;
     SDL_GPUShaderFormat format;
     SDL_GPUShaderStage stage;
     Uint32 num_samplers;
@@ -1141,7 +1141,7 @@ typedef struct SDL_GPUTextureCreateInfo
 {
     SDL_GPUTextureType type;
     SDL_GPUTextureFormat format;
-    SDL_GPUTextureUsageFlags usage_flags;
+    SDL_GPUTextureUsageFlags usage;
     Uint32 width;
     Uint32 height;
     Uint32 layer_count_or_depth;
@@ -1160,7 +1160,7 @@ typedef struct SDL_GPUTextureCreateInfo
 
 typedef struct SDL_GPUBufferCreateInfo
 {
-    SDL_GPUBufferUsageFlags usage_flags;
+    SDL_GPUBufferUsageFlags usage;
     Uint32 size;
 
     SDL_PropertiesID props;
@@ -1180,7 +1180,7 @@ typedef struct SDL_GPURasterizerState
 {
     SDL_GPUFillMode fill_mode;
     SDL_GPUCullMode cull_mode;
-    SDL_GPUFrontFace frontFace;
+    SDL_GPUFrontFace front_face;
     SDL_bool enable_depth_bias;
     Uint8 padding1;
     Uint8 padding2;
@@ -1246,7 +1246,7 @@ typedef struct SDL_GPUComputePipelineCreateInfo
 {
     size_t code_size;
     const Uint8 *code;
-    const char *entrypoint_name;
+    const char *entrypoint;
     SDL_GPUShaderFormat format;
     Uint32 num_readonly_storage_textures;
     Uint32 num_readonly_storage_buffers;
@@ -2182,7 +2182,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexBuffers(
  * calls.
  *
  * \param render_pass a render pass handle.
- * \param pBinding a pointer to a struct containing an index buffer and
+ * \param binding a pointer to a struct containing an index buffer and
  *                 offset.
  * \param index_element_size whether the index values in the buffer are 16- or
  *                         32-bit.
@@ -2191,7 +2191,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexBuffers(
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUIndexBuffer(
     SDL_GPURenderPass *render_pass,
-    const SDL_GPUBufferBinding *pBinding,
+    const SDL_GPUBufferBinding *binding,
     SDL_GPUIndexElementSize index_element_size);
 
 /**

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -70,7 +70,7 @@ SDL_DYNAPI_PROC(SDL_JoystickID,SDL_AttachVirtualJoystick,(const SDL_VirtualJoyst
 SDL_DYNAPI_PROC(SDL_bool,SDL_AudioDevicePaused,(SDL_AudioDeviceID a),(a),return)
 SDL_DYNAPI_PROC(SDL_GPUComputePass*,SDL_BeginGPUComputePass,(SDL_GPUCommandBuffer *a, const SDL_GPUStorageTextureWriteOnlyBinding *b, Uint32 c, const SDL_GPUStorageBufferWriteOnlyBinding *d, Uint32 e),(a,b,c,d,e),return)
 SDL_DYNAPI_PROC(SDL_GPUCopyPass*,SDL_BeginGPUCopyPass,(SDL_GPUCommandBuffer *a),(a),return)
-SDL_DYNAPI_PROC(SDL_GPURenderPass*,SDL_BeginGPURenderPass,(SDL_GPUCommandBuffer *a, const SDL_GPUColorAttachmentInfo *b, Uint32 c, const SDL_GPUDepthStencilAttachmentInfo *d),(a,b,c,d),return)
+SDL_DYNAPI_PROC(SDL_GPURenderPass*,SDL_BeginGPURenderPass,(SDL_GPUCommandBuffer *a, const SDL_GPUColorTargetInfo *b, Uint32 c, const SDL_GPUDepthStencilTargetInfo *d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_BindAudioStream,(SDL_AudioDeviceID a, SDL_AudioStream *b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_BindAudioStreams,(SDL_AudioDeviceID a, SDL_AudioStream **b, int c),(a,b,c),return)
 SDL_DYNAPI_PROC(void,SDL_BindGPUComputePipeline,(SDL_GPUComputePass *a, SDL_GPUComputePipeline *b),(a,b),)

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -42,39 +42,39 @@
 
 #define CHECK_ANY_PASS_IN_PROGRESS(msg, retval)                                 \
     if (                                                                        \
-        ((CommandBufferCommonHeader *)command_buffer)->render_pass.inProgress ||  \
-        ((CommandBufferCommonHeader *)command_buffer)->compute_pass.inProgress || \
-        ((CommandBufferCommonHeader *)command_buffer)->copy_pass.inProgress) {    \
+        ((CommandBufferCommonHeader *)command_buffer)->render_pass.in_progress ||  \
+        ((CommandBufferCommonHeader *)command_buffer)->compute_pass.in_progress || \
+        ((CommandBufferCommonHeader *)command_buffer)->copy_pass.in_progress) {    \
         SDL_assert_release(!msg);                                               \
         return retval;                                                          \
     }
 
 #define CHECK_RENDERPASS                                     \
-    if (!((Pass *)render_pass)->inProgress) {                 \
+    if (!((Pass *)render_pass)->in_progress) {                 \
         SDL_assert_release(!"Render pass not in progress!"); \
         return;                                              \
     }
 
 #define CHECK_GRAPHICS_PIPELINE_BOUND                                                       \
-    if (!((CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER)->graphicsPipelineBound) { \
+    if (!((CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER)->graphics_pipeline_bound) { \
         SDL_assert_release(!"Graphics pipeline not bound!");                                \
         return;                                                                             \
     }
 
 #define CHECK_COMPUTEPASS                                     \
-    if (!((Pass *)compute_pass)->inProgress) {                 \
+    if (!((Pass *)compute_pass)->in_progress) {                 \
         SDL_assert_release(!"Compute pass not in progress!"); \
         return;                                               \
     }
 
 #define CHECK_COMPUTE_PIPELINE_BOUND                                                        \
-    if (!((CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER)->computePipelineBound) { \
+    if (!((CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER)->compute_pipeline_bound) { \
         SDL_assert_release(!"Compute pipeline not bound!");                                 \
         return;                                                                             \
     }
 
 #define CHECK_COPYPASS                                     \
-    if (!((Pass *)copy_pass)->inProgress) {                 \
+    if (!((Pass *)copy_pass)->in_progress) {                 \
         SDL_assert_release(!"Copy pass not in progress!"); \
         return;                                            \
     }
@@ -323,7 +323,7 @@ void SDL_GPU_BlitCommon(
     blitFragmentUniforms.mip_level = source->mip_level;
 
     layerDivisor = (srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D) ? srcHeader->info.layer_count_or_depth : 1;
-    blitFragmentUniforms.layerOrDepth = (float)source->layer_or_depth_plane / layerDivisor;
+    blitFragmentUniforms.layer_or_depth = (float)source->layer_or_depth_plane / layerDivisor;
 
     if (flip_mode & SDL_FLIP_HORIZONTAL) {
         blitFragmentUniforms.left += blitFragmentUniforms.width;
@@ -1067,13 +1067,13 @@ SDL_GPUCommandBuffer *SDL_AcquireGPUCommandBuffer(
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
     commandBufferHeader->device = device;
     commandBufferHeader->render_pass.command_buffer = command_buffer;
-    commandBufferHeader->render_pass.inProgress = false;
-    commandBufferHeader->graphicsPipelineBound = false;
+    commandBufferHeader->render_pass.in_progress = false;
+    commandBufferHeader->graphics_pipeline_bound = false;
     commandBufferHeader->compute_pass.command_buffer = command_buffer;
-    commandBufferHeader->compute_pass.inProgress = false;
-    commandBufferHeader->computePipelineBound = false;
+    commandBufferHeader->compute_pass.in_progress = false;
+    commandBufferHeader->compute_pipeline_bound = false;
     commandBufferHeader->copy_pass.command_buffer = command_buffer;
-    commandBufferHeader->copy_pass.inProgress = false;
+    commandBufferHeader->copy_pass.in_progress = false;
     commandBufferHeader->submitted = false;
 
     return command_buffer;
@@ -1205,7 +1205,7 @@ SDL_GPURenderPass *SDL_BeginGPURenderPass(
         depth_stencil_attachment_info);
 
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
-    commandBufferHeader->render_pass.inProgress = true;
+    commandBufferHeader->render_pass.in_progress = true;
     return (SDL_GPURenderPass *)&(commandBufferHeader->render_pass);
 }
 
@@ -1229,7 +1229,7 @@ void SDL_BindGPUGraphicsPipeline(
         graphics_pipeline);
 
     commandBufferHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
-    commandBufferHeader->graphicsPipelineBound = true;
+    commandBufferHeader->graphics_pipeline_bound = true;
 }
 
 void SDL_SetGPUViewport(
@@ -1646,8 +1646,8 @@ void SDL_EndGPURenderPass(
         RENDERPASS_COMMAND_BUFFER);
 
     commandBufferCommonHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
-    commandBufferCommonHeader->render_pass.inProgress = false;
-    commandBufferCommonHeader->graphicsPipelineBound = false;
+    commandBufferCommonHeader->render_pass.in_progress = false;
+    commandBufferCommonHeader->graphics_pipeline_bound = false;
 }
 
 // Compute Pass
@@ -1694,7 +1694,7 @@ SDL_GPUComputePass *SDL_BeginGPUComputePass(
         num_storage_buffer_bindings);
 
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
-    commandBufferHeader->compute_pass.inProgress = true;
+    commandBufferHeader->compute_pass.in_progress = true;
     return (SDL_GPUComputePass *)&(commandBufferHeader->compute_pass);
 }
 
@@ -1722,7 +1722,7 @@ void SDL_BindGPUComputePipeline(
         compute_pipeline);
 
     commandBufferHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
-    commandBufferHeader->computePipelineBound = true;
+    commandBufferHeader->compute_pipeline_bound = true;
 }
 
 void SDL_BindGPUComputeStorageTextures(
@@ -1839,8 +1839,8 @@ void SDL_EndGPUComputePass(
         COMPUTEPASS_COMMAND_BUFFER);
 
     commandBufferCommonHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
-    commandBufferCommonHeader->compute_pass.inProgress = false;
-    commandBufferCommonHeader->computePipelineBound = false;
+    commandBufferCommonHeader->compute_pass.in_progress = false;
+    commandBufferCommonHeader->compute_pipeline_bound = false;
 }
 
 // TransferBuffer Data
@@ -1898,7 +1898,7 @@ SDL_GPUCopyPass *SDL_BeginGPUCopyPass(
         command_buffer);
 
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
-    commandBufferHeader->copy_pass.inProgress = true;
+    commandBufferHeader->copy_pass.in_progress = true;
     return (SDL_GPUCopyPass *)&(commandBufferHeader->copy_pass);
 }
 
@@ -2081,7 +2081,7 @@ void SDL_EndGPUCopyPass(
     COPYPASS_DEVICE->EndCopyPass(
         COPYPASS_COMMAND_BUFFER);
 
-    ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->copy_pass.inProgress = false;
+    ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->copy_pass.in_progress = false;
 }
 
 void SDL_GenerateMipmapsForGPUTexture(
@@ -2344,9 +2344,9 @@ void SDL_SubmitGPUCommandBuffer(
     if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
         if (
-            commandBufferHeader->render_pass.inProgress ||
-            commandBufferHeader->compute_pass.inProgress ||
-            commandBufferHeader->copy_pass.inProgress) {
+            commandBufferHeader->render_pass.in_progress ||
+            commandBufferHeader->compute_pass.in_progress ||
+            commandBufferHeader->copy_pass.in_progress) {
             SDL_assert_release(!"Cannot submit command buffer while a pass is in progress!");
             return;
         }
@@ -2371,9 +2371,9 @@ SDL_GPUFence *SDL_SubmitGPUCommandBufferAndAcquireFence(
     if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         if (
-            commandBufferHeader->render_pass.inProgress ||
-            commandBufferHeader->compute_pass.inProgress ||
-            commandBufferHeader->copy_pass.inProgress) {
+            commandBufferHeader->render_pass.in_progress ||
+            commandBufferHeader->compute_pass.in_progress ||
+            commandBufferHeader->copy_pass.in_progress) {
             SDL_assert_release(!"Cannot submit command buffer while a pass is in progress!");
             return NULL;
         }

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -140,63 +140,63 @@ static const SDL_GPUBootstrap *backends[] = {
 
 SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
     SDL_GPUDevice *device,
-    SDL_GPUTextureType sourceTextureType,
-    SDL_GPUTextureFormat destinationFormat,
-    SDL_GPUShader *blitVertexShader,
-    SDL_GPUShader *blitFrom2DShader,
-    SDL_GPUShader *blitFrom2DArrayShader,
-    SDL_GPUShader *blitFrom3DShader,
-    SDL_GPUShader *blitFromCubeShader,
-    BlitPipelineCacheEntry **blitPipelines,
-    Uint32 *blitPipelineCount,
-    Uint32 *blitPipelineCapacity)
+    SDL_GPUTextureType source_texture_type,
+    SDL_GPUTextureFormat destination_format,
+    SDL_GPUShader *blit_vertex_shader,
+    SDL_GPUShader *blit_from_2d_shader,
+    SDL_GPUShader *blit_from_2d_array_shader,
+    SDL_GPUShader *blit_from_3d_shader,
+    SDL_GPUShader *blit_from_cube_shader,
+    BlitPipelineCacheEntry **blit_pipelines,
+    Uint32 *blit_pipeline_count,
+    Uint32 *blit_pipeline_capacity)
 {
-    SDL_GPUGraphicsPipelineCreateInfo blitPipelineCreateInfo;
+    SDL_GPUGraphicsPipelineCreateInfo blit_pipeline_create_info;
     SDL_GPUColorTargetDescription color_target_desc;
     SDL_GPUGraphicsPipeline *pipeline;
 
-    if (blitPipelineCount == NULL) {
+    if (blit_pipeline_count == NULL) {
         // use pre-created, format-agnostic pipelines
-        return (*blitPipelines)[sourceTextureType].pipeline;
+        return (*blit_pipelines)[source_texture_type].pipeline;
     }
 
-    for (Uint32 i = 0; i < *blitPipelineCount; i += 1) {
-        if ((*blitPipelines)[i].type == sourceTextureType && (*blitPipelines)[i].format == destinationFormat) {
-            return (*blitPipelines)[i].pipeline;
+    for (Uint32 i = 0; i < *blit_pipeline_count; i += 1) {
+        if ((*blit_pipelines)[i].type == source_texture_type && (*blit_pipelines)[i].format == destination_format) {
+            return (*blit_pipelines)[i].pipeline;
         }
     }
 
     // No pipeline found, we'll need to make one!
-    SDL_zero(blitPipelineCreateInfo);
+    SDL_zero(blit_pipeline_create_info);
 
     SDL_zero(color_target_desc);
     color_target_desc.blend_state.color_write_mask = 0xF;
-    color_target_desc.format = destinationFormat;
+    color_target_desc.format = destination_format;
 
-    blitPipelineCreateInfo.target_info.color_target_descriptions = &color_target_desc;
-    blitPipelineCreateInfo.target_info.num_color_targets = 1;
-    blitPipelineCreateInfo.target_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM; // arbitrary
-    blitPipelineCreateInfo.target_info.has_depth_stencil_target = false;
+    blit_pipeline_create_info.target_info.color_target_descriptions = &color_target_desc;
+    blit_pipeline_create_info.target_info.num_color_targets = 1;
+    blit_pipeline_create_info.target_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM; // arbitrary
+    blit_pipeline_create_info.target_info.has_depth_stencil_target = false;
 
-    blitPipelineCreateInfo.vertex_shader = blitVertexShader;
-    if (sourceTextureType == SDL_GPU_TEXTURETYPE_CUBE) {
-        blitPipelineCreateInfo.fragment_shader = blitFromCubeShader;
-    } else if (sourceTextureType == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
-        blitPipelineCreateInfo.fragment_shader = blitFrom2DArrayShader;
-    } else if (sourceTextureType == SDL_GPU_TEXTURETYPE_3D) {
-        blitPipelineCreateInfo.fragment_shader = blitFrom3DShader;
+    blit_pipeline_create_info.vertex_shader = blit_vertex_shader;
+    if (source_texture_type == SDL_GPU_TEXTURETYPE_CUBE) {
+        blit_pipeline_create_info.fragment_shader = blit_from_cube_shader;
+    } else if (source_texture_type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
+        blit_pipeline_create_info.fragment_shader = blit_from_2d_array_shader;
+    } else if (source_texture_type == SDL_GPU_TEXTURETYPE_3D) {
+        blit_pipeline_create_info.fragment_shader = blit_from_3d_shader;
     } else {
-        blitPipelineCreateInfo.fragment_shader = blitFrom2DShader;
+        blit_pipeline_create_info.fragment_shader = blit_from_2d_shader;
     }
 
-    blitPipelineCreateInfo.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
-    blitPipelineCreateInfo.multisample_state.sample_mask = 0xFFFFFFFF;
+    blit_pipeline_create_info.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    blit_pipeline_create_info.multisample_state.sample_mask = 0xFFFFFFFF;
 
-    blitPipelineCreateInfo.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+    blit_pipeline_create_info.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 
     pipeline = SDL_CreateGPUGraphicsPipeline(
         device,
-        &blitPipelineCreateInfo);
+        &blit_pipeline_create_info);
 
     if (pipeline == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create graphics pipeline for blit");
@@ -205,16 +205,16 @@ SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
 
     // Cache the new pipeline
     EXPAND_ARRAY_IF_NEEDED(
-        (*blitPipelines),
+        (*blit_pipelines),
         BlitPipelineCacheEntry,
-        *blitPipelineCount + 1,
-        *blitPipelineCapacity,
-        *blitPipelineCapacity * 2)
+        *blit_pipeline_count + 1,
+        *blit_pipeline_capacity,
+        *blit_pipeline_capacity * 2)
 
-    (*blitPipelines)[*blitPipelineCount].pipeline = pipeline;
-    (*blitPipelines)[*blitPipelineCount].type = sourceTextureType;
-    (*blitPipelines)[*blitPipelineCount].format = destinationFormat;
-    *blitPipelineCount += 1;
+    (*blit_pipelines)[*blit_pipeline_count].pipeline = pipeline;
+    (*blit_pipelines)[*blit_pipeline_count].type = source_texture_type;
+    (*blit_pipelines)[*blit_pipeline_count].format = destination_format;
+    *blit_pipeline_count += 1;
 
     return pipeline;
 }
@@ -226,53 +226,53 @@ void SDL_GPU_BlitCommon(
     SDL_FlipMode flip_mode,
     SDL_GPUFilter filter,
     bool cycle,
-    SDL_GPUSampler *blitLinearSampler,
-    SDL_GPUSampler *blitNearestSampler,
-    SDL_GPUShader *blitVertexShader,
-    SDL_GPUShader *blitFrom2DShader,
-    SDL_GPUShader *blitFrom2DArrayShader,
-    SDL_GPUShader *blitFrom3DShader,
-    SDL_GPUShader *blitFromCubeShader,
-    BlitPipelineCacheEntry **blitPipelines,
-    Uint32 *blitPipelineCount,
-    Uint32 *blitPipelineCapacity)
+    SDL_GPUSampler *blit_linear_sampler,
+    SDL_GPUSampler *blit_nearest_sampler,
+    SDL_GPUShader *blit_vertex_shader,
+    SDL_GPUShader *blit_from_2d_shader,
+    SDL_GPUShader *blit_from_2d_array_shader,
+    SDL_GPUShader *blit_from_3d_shader,
+    SDL_GPUShader *blit_from_cube_shader,
+    BlitPipelineCacheEntry **blit_pipelines,
+    Uint32 *blit_pipeline_count,
+    Uint32 *blit_pipeline_capacity)
 {
     CommandBufferCommonHeader *cmdbufHeader = (CommandBufferCommonHeader *)command_buffer;
     SDL_GPURenderPass *render_pass;
-    TextureCommonHeader *srcHeader = (TextureCommonHeader *)source->texture;
-    TextureCommonHeader *dstHeader = (TextureCommonHeader *)destination->texture;
-    SDL_GPUGraphicsPipeline *blitPipeline;
+    TextureCommonHeader *src_header = (TextureCommonHeader *)source->texture;
+    TextureCommonHeader *dst_header = (TextureCommonHeader *)destination->texture;
+    SDL_GPUGraphicsPipeline *blit_pipeline;
     SDL_GPUColorTargetInfo color_target_info;
     SDL_GPUViewport viewport;
-    SDL_GPUTextureSamplerBinding textureSamplerBinding;
-    BlitFragmentUniforms blitFragmentUniforms;
-    Uint32 layerDivisor;
+    SDL_GPUTextureSamplerBinding texture_sampler_binding;
+    BlitFragmentUniforms blit_fragment_uniforms;
+    Uint32 layer_divisor;
 
-    blitPipeline = SDL_GPU_FetchBlitPipeline(
+    blit_pipeline = SDL_GPU_FetchBlitPipeline(
         cmdbufHeader->device,
-        srcHeader->info.type,
-        dstHeader->info.format,
-        blitVertexShader,
-        blitFrom2DShader,
-        blitFrom2DArrayShader,
-        blitFrom3DShader,
-        blitFromCubeShader,
-        blitPipelines,
-        blitPipelineCount,
-        blitPipelineCapacity);
+        src_header->info.type,
+        dst_header->info.format,
+        blit_vertex_shader,
+        blit_from_2d_shader,
+        blit_from_2d_array_shader,
+        blit_from_3d_shader,
+        blit_from_cube_shader,
+        blit_pipelines,
+        blit_pipeline_count,
+        blit_pipeline_capacity);
 
-    if (blitPipeline == NULL) {
+    if (blit_pipeline == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not fetch blit pipeline");
         return;
     }
 
     // If the entire destination is blitted, we don't have to load
     if (
-        dstHeader->info.layer_count_or_depth == 1 &&
-        dstHeader->info.num_levels == 1 &&
-        dstHeader->info.type != SDL_GPU_TEXTURETYPE_3D &&
-        destination->w == dstHeader->info.width &&
-        destination->h == dstHeader->info.height) {
+        dst_header->info.layer_count_or_depth == 1 &&
+        dst_header->info.num_levels == 1 &&
+        dst_header->info.type != SDL_GPU_TEXTURETYPE_3D &&
+        destination->w == dst_header->info.width &&
+        destination->h == dst_header->info.height) {
         color_target_info.load_op = SDL_GPU_LOADOP_DONT_CARE;
     } else {
         color_target_info.load_op = SDL_GPU_LOADOP_LOAD;
@@ -304,42 +304,42 @@ void SDL_GPU_BlitCommon(
 
     SDL_BindGPUGraphicsPipeline(
         render_pass,
-        blitPipeline);
+        blit_pipeline);
 
-    textureSamplerBinding.texture = source->texture;
-    textureSamplerBinding.sampler =
-        filter == SDL_GPU_FILTER_NEAREST ? blitNearestSampler : blitLinearSampler;
+    texture_sampler_binding.texture = source->texture;
+    texture_sampler_binding.sampler =
+        filter == SDL_GPU_FILTER_NEAREST ? blit_nearest_sampler : blit_linear_sampler;
 
     SDL_BindGPUFragmentSamplers(
         render_pass,
         0,
-        &textureSamplerBinding,
+        &texture_sampler_binding,
         1);
 
-    blitFragmentUniforms.left = (float)source->x / (srcHeader->info.width >> source->mip_level);
-    blitFragmentUniforms.top = (float)source->y / (srcHeader->info.height >> source->mip_level);
-    blitFragmentUniforms.width = (float)source->w / (srcHeader->info.width >> source->mip_level);
-    blitFragmentUniforms.height = (float)source->h / (srcHeader->info.height >> source->mip_level);
-    blitFragmentUniforms.mip_level = source->mip_level;
+    blit_fragment_uniforms.left = (float)source->x / (src_header->info.width >> source->mip_level);
+    blit_fragment_uniforms.top = (float)source->y / (src_header->info.height >> source->mip_level);
+    blit_fragment_uniforms.width = (float)source->w / (src_header->info.width >> source->mip_level);
+    blit_fragment_uniforms.height = (float)source->h / (src_header->info.height >> source->mip_level);
+    blit_fragment_uniforms.mip_level = source->mip_level;
 
-    layerDivisor = (srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D) ? srcHeader->info.layer_count_or_depth : 1;
-    blitFragmentUniforms.layer_or_depth = (float)source->layer_or_depth_plane / layerDivisor;
+    layer_divisor = (src_header->info.type == SDL_GPU_TEXTURETYPE_3D) ? src_header->info.layer_count_or_depth : 1;
+    blit_fragment_uniforms.layer_or_depth = (float)source->layer_or_depth_plane / layer_divisor;
 
     if (flip_mode & SDL_FLIP_HORIZONTAL) {
-        blitFragmentUniforms.left += blitFragmentUniforms.width;
-        blitFragmentUniforms.width *= -1;
+        blit_fragment_uniforms.left += blit_fragment_uniforms.width;
+        blit_fragment_uniforms.width *= -1;
     }
 
     if (flip_mode & SDL_FLIP_VERTICAL) {
-        blitFragmentUniforms.top += blitFragmentUniforms.height;
-        blitFragmentUniforms.height *= -1;
+        blit_fragment_uniforms.top += blit_fragment_uniforms.height;
+        blit_fragment_uniforms.height *= -1;
     }
 
     SDL_PushGPUFragmentUniformData(
         command_buffer,
         0,
-        &blitFragmentUniforms,
-        sizeof(blitFragmentUniforms));
+        &blit_fragment_uniforms,
+        sizeof(blit_fragment_uniforms));
 
     SDL_DrawGPUPrimitives(render_pass, 3, 1, 0, 0);
     SDL_EndGPURenderPass(render_pass);
@@ -357,8 +357,8 @@ static SDL_GPUDriver SDL_GPUSelectBackend(
     // Environment/Properties override...
     if (gpudriver != NULL) {
         for (i = 0; backends[i]; i += 1) {
-            if (SDL_strcasecmp(gpudriver, backends[i]->Name) == 0) {
-                if (!(backends[i]->shaderFormats & format_flags)) {
+            if (SDL_strcasecmp(gpudriver, backends[i]->name) == 0) {
+                if (!(backends[i]->shader_formats & format_flags)) {
                     SDL_LogError(SDL_LOG_CATEGORY_GPU, "Required shader format for backend %s not provided!", gpudriver);
                     return SDL_GPU_DRIVER_INVALID;
                 }
@@ -373,7 +373,7 @@ static SDL_GPUDriver SDL_GPUSelectBackend(
     }
 
     for (i = 0; backends[i]; i += 1) {
-        if ((backends[i]->shaderFormats & format_flags) == 0) {
+        if ((backends[i]->shader_formats & format_flags) == 0) {
             // Don't select a backend which doesn't support the app's shaders.
             continue;
         }
@@ -469,7 +469,7 @@ SDL_GPUDevice *SDL_CreateGPUDeviceWithProperties(SDL_PropertiesID props)
                 result = backends[i]->CreateDevice(debug_mode, preferLowPower, props);
                 if (result != NULL) {
                     result->backend = backends[i]->backendflag;
-                    result->shaderFormats = backends[i]->shaderFormats;
+                    result->shader_formats = backends[i]->shader_formats;
                     result->debug_mode = debug_mode;
                     break;
                 }
@@ -604,7 +604,7 @@ SDL_GPUComputePipeline *SDL_CreateGPUComputePipeline(
     }
 
     if (device->debug_mode) {
-        if (!(createinfo->format & device->shaderFormats)) {
+        if (!(createinfo->format & device->shader_formats)) {
             SDL_assert_release(!"Incompatible shader format for GPU backend");
             return NULL;
         }
@@ -688,7 +688,7 @@ SDL_GPUShader *SDL_CreateGPUShader(
     }
 
     if (device->debug_mode) {
-        if (!(createinfo->format & device->shaderFormats)) {
+        if (!(createinfo->format & device->shader_formats)) {
             SDL_assert_release(!"Incompatible shader format for GPU backend");
             return NULL;
         }

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -262,10 +262,10 @@ SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
     Uint32 *blitPipelineCapacity);
 
 void SDL_GPU_BlitCommon(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flip_mode,
+    SDL_FlipMode flipMode,
     SDL_GPUFilter filter,
     bool cycle,
     SDL_GPUSampler *blitLinearSampler,
@@ -317,7 +317,7 @@ struct SDL_GPUDevice
 
     SDL_GPUBuffer *(*CreateBuffer)(
         SDL_GPURenderer *driverData,
-        SDL_GPUBufferUsageFlags usage_flags,
+        SDL_GPUBufferUsageFlags usageFlags,
         Uint32 size);
 
     SDL_GPUTransferBuffer *(*CreateTransferBuffer)(
@@ -338,15 +338,15 @@ struct SDL_GPUDevice
         const char *text);
 
     void (*InsertDebugLabel)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const char *text);
 
     void (*PushDebugGroup)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const char *name);
 
     void (*PopDebugGroup)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     // Disposal
 
@@ -364,7 +364,7 @@ struct SDL_GPUDevice
 
     void (*ReleaseTransferBuffer)(
         SDL_GPURenderer *driverData,
-        SDL_GPUTransferBuffer *transfer_buffer);
+        SDL_GPUTransferBuffer *transferBuffer);
 
     void (*ReleaseShader)(
         SDL_GPURenderer *driverData,
@@ -372,206 +372,206 @@ struct SDL_GPUDevice
 
     void (*ReleaseComputePipeline)(
         SDL_GPURenderer *driverData,
-        SDL_GPUComputePipeline *compute_pipeline);
+        SDL_GPUComputePipeline *computePipeline);
 
     void (*ReleaseGraphicsPipeline)(
         SDL_GPURenderer *driverData,
-        SDL_GPUGraphicsPipeline *graphics_pipeline);
+        SDL_GPUGraphicsPipeline *graphicsPipeline);
 
     // Render Pass
 
     void (*BeginRenderPass)(
-        SDL_GPUCommandBuffer *command_buffer,
-        const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-        Uint32 num_color_attachments,
-        const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info);
+        SDL_GPUCommandBuffer *commandBuffer,
+        const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
+        Uint32 numColorAttachments,
+        const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo);
 
     void (*BindGraphicsPipeline)(
-        SDL_GPUCommandBuffer *command_buffer,
-        SDL_GPUGraphicsPipeline *graphics_pipeline);
+        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUGraphicsPipeline *graphicsPipeline);
 
     void (*SetViewport)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUViewport *viewport);
 
     void (*SetScissor)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_Rect *scissor);
 
     void (*SetBlendConstants)(
-        SDL_GPUCommandBuffer *command_buffer,
-        SDL_FColor blend_constants);
+        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_FColor blendConstants);
 
     void (*SetStencilReference)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         Uint8 reference);
 
     void (*BindVertexBuffers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_binding,
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstBinding,
         const SDL_GPUBufferBinding *bindings,
-        Uint32 num_bindings);
+        Uint32 numBindings);
 
     void (*BindIndexBuffer)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUBufferBinding *pBinding,
-        SDL_GPUIndexElementSize index_element_size);
+        SDL_GPUIndexElementSize indexElementSize);
 
     void (*BindVertexSamplers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+        Uint32 numBindings);
 
     void (*BindVertexStorageTextures)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUTexture *const *storage_textures,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUTexture *const *storageTextures,
+        Uint32 numBindings);
 
     void (*BindVertexStorageBuffers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUBuffer *const *storage_buffers,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUBuffer *const *storageBuffers,
+        Uint32 numBindings);
 
     void (*BindFragmentSamplers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+        Uint32 numBindings);
 
     void (*BindFragmentStorageTextures)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUTexture *const *storage_textures,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUTexture *const *storageTextures,
+        Uint32 numBindings);
 
     void (*BindFragmentStorageBuffers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUBuffer *const *storage_buffers,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUBuffer *const *storageBuffers,
+        Uint32 numBindings);
 
     void (*PushVertexUniformData)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 slot_index,
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 slotIndex,
         const void *data,
         Uint32 length);
 
     void (*PushFragmentUniformData)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 slot_index,
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 slotIndex,
         const void *data,
         Uint32 length);
 
     void (*DrawIndexedPrimitives)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 num_indices,
-        Uint32 num_instances,
-        Uint32 first_index,
-        Sint32 vertex_offset,
-        Uint32 first_instance);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 numIndices,
+        Uint32 numInstances,
+        Uint32 firstIndex,
+        Sint32 vertexOffset,
+        Uint32 firstInstance);
 
     void (*DrawPrimitives)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 num_vertices,
-        Uint32 num_instances,
-        Uint32 first_vertex,
-        Uint32 first_instance);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 numVertices,
+        Uint32 numInstances,
+        Uint32 firstVertex,
+        Uint32 firstInstance);
 
     void (*DrawPrimitivesIndirect)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_GPUBuffer *buffer,
         Uint32 offset,
-        Uint32 draw_count,
+        Uint32 drawCount,
         Uint32 pitch);
 
     void (*DrawIndexedPrimitivesIndirect)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_GPUBuffer *buffer,
         Uint32 offset,
-        Uint32 draw_count,
+        Uint32 drawCount,
         Uint32 pitch);
 
     void (*EndRenderPass)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     // Compute Pass
 
     void (*BeginComputePass)(
-        SDL_GPUCommandBuffer *command_buffer,
-        const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
-        Uint32 num_storage_texture_bindings,
-        const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
-        Uint32 num_storage_buffer_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
+        Uint32 numStorageTextureBindings,
+        const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
+        Uint32 numStorageBufferBindings);
 
     void (*BindComputePipeline)(
-        SDL_GPUCommandBuffer *command_buffer,
-        SDL_GPUComputePipeline *compute_pipeline);
+        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUComputePipeline *computePipeline);
 
     void (*BindComputeStorageTextures)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUTexture *const *storage_textures,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUTexture *const *storageTextures,
+        Uint32 numBindings);
 
     void (*BindComputeStorageBuffers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUBuffer *const *storage_buffers,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUBuffer *const *storageBuffers,
+        Uint32 numBindings);
 
     void (*PushComputeUniformData)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 slot_index,
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 slotIndex,
         const void *data,
         Uint32 length);
 
     void (*DispatchCompute)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 groupcount_x,
-        Uint32 groupcount_y,
-        Uint32 groupcount_z);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 groupcountX,
+        Uint32 groupcountY,
+        Uint32 groupcountZ);
 
     void (*DispatchComputeIndirect)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_GPUBuffer *buffer,
         Uint32 offset);
 
     void (*EndComputePass)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     // TransferBuffer Data
 
     void *(*MapTransferBuffer)(
         SDL_GPURenderer *device,
-        SDL_GPUTransferBuffer *transfer_buffer,
+        SDL_GPUTransferBuffer *transferBuffer,
         bool cycle);
 
     void (*UnmapTransferBuffer)(
         SDL_GPURenderer *device,
-        SDL_GPUTransferBuffer *transfer_buffer);
+        SDL_GPUTransferBuffer *transferBuffer);
 
     // Copy Pass
 
     void (*BeginCopyPass)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     void (*UploadToTexture)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUTextureTransferInfo *source,
         const SDL_GPUTextureRegion *destination,
         bool cycle);
 
     void (*UploadToBuffer)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUTransferBufferLocation *source,
         const SDL_GPUBufferRegion *destination,
         bool cycle);
 
     void (*CopyTextureToTexture)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUTextureLocation *source,
         const SDL_GPUTextureLocation *destination,
         Uint32 w,
@@ -580,34 +580,34 @@ struct SDL_GPUDevice
         bool cycle);
 
     void (*CopyBufferToBuffer)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUBufferLocation *source,
         const SDL_GPUBufferLocation *destination,
         Uint32 size,
         bool cycle);
 
     void (*GenerateMipmaps)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_GPUTexture *texture);
 
     void (*DownloadFromTexture)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUTextureRegion *source,
         const SDL_GPUTextureTransferInfo *destination);
 
     void (*DownloadFromBuffer)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUBufferRegion *source,
         const SDL_GPUTransferBufferLocation *destination);
 
     void (*EndCopyPass)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     void (*Blit)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUBlitRegion *source,
         const SDL_GPUBlitRegion *destination,
-        SDL_FlipMode flip_mode,
+        SDL_FlipMode flipMode,
         SDL_GPUFilter filter,
         bool cycle);
 
@@ -616,12 +616,12 @@ struct SDL_GPUDevice
     bool (*SupportsSwapchainComposition)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUSwapchainComposition swapchain_composition);
+        SDL_GPUSwapchainComposition swapchainComposition);
 
     bool (*SupportsPresentMode)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUPresentMode present_mode);
+        SDL_GPUPresentMode presentMode);
 
     bool (*ClaimWindow)(
         SDL_GPURenderer *driverData,
@@ -634,8 +634,8 @@ struct SDL_GPUDevice
     bool (*SetSwapchainParameters)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUSwapchainComposition swapchain_composition,
-        SDL_GPUPresentMode present_mode);
+        SDL_GPUSwapchainComposition swapchainComposition,
+        SDL_GPUPresentMode presentMode);
 
     SDL_GPUTextureFormat (*GetSwapchainTextureFormat)(
         SDL_GPURenderer *driverData,
@@ -645,25 +645,25 @@ struct SDL_GPUDevice
         SDL_GPURenderer *driverData);
 
     SDL_GPUTexture *(*AcquireSwapchainTexture)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_Window *window,
         Uint32 *w,
         Uint32 *h);
 
     void (*Submit)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     SDL_GPUFence *(*SubmitAndAcquireFence)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     void (*Wait)(
         SDL_GPURenderer *driverData);
 
     void (*WaitForFences)(
         SDL_GPURenderer *driverData,
-        bool wait_all,
+        bool waitAll,
         SDL_GPUFence *const *fences,
-        Uint32 num_fences);
+        Uint32 numFences);
 
     bool (*QueryFence)(
         SDL_GPURenderer *driverData,
@@ -784,7 +784,7 @@ typedef struct SDL_GPUBootstrap
     const SDL_GPUDriver backendflag;
     const SDL_GPUShaderFormat shaderFormats;
     bool (*PrepareDriver)(SDL_VideoDevice *_this);
-    SDL_GPUDevice *(*CreateDevice)(bool debug_mode, bool preferLowPower, SDL_PropertiesID props);
+    SDL_GPUDevice *(*CreateDevice)(bool debugMode, bool preferLowPower, SDL_PropertiesID props);
 } SDL_GPUBootstrap;
 
 #ifdef __cplusplus

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -382,9 +382,9 @@ struct SDL_GPUDevice
 
     void (*BeginRenderPass)(
         SDL_GPUCommandBuffer *commandBuffer,
-        const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-        Uint32 numColorAttachments,
-        const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo);
+        const SDL_GPUColorTargetInfo *colorTargetInfos,
+        Uint32 numColorTargets,
+        const SDL_GPUDepthStencilTargetInfo *depthStencilTargetInfo);
 
     void (*BindGraphicsPipeline)(
         SDL_GPUCommandBuffer *commandBuffer,

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -414,7 +414,7 @@ struct SDL_GPUDevice
 
     void (*BindIndexBuffer)(
         SDL_GPUCommandBuffer *commandBuffer,
-        const SDL_GPUBufferBinding *pBinding,
+        const SDL_GPUBufferBinding *binding,
         SDL_GPUIndexElementSize indexElementSize);
 
     void (*BindVertexSamplers)(

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   Simple DirectMedia Layer
   Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
 
@@ -29,16 +29,16 @@
 typedef struct Pass
 {
     SDL_GPUCommandBuffer *command_buffer;
-    bool inProgress;
+    bool in_progress;
 } Pass;
 
 typedef struct CommandBufferCommonHeader
 {
     SDL_GPUDevice *device;
     Pass render_pass;
-    bool graphicsPipelineBound;
+    bool graphics_pipeline_bound;
     Pass compute_pass;
-    bool computePipelineBound;
+    bool compute_pipeline_bound;
     Pass copy_pass;
     bool submitted;
 } CommandBufferCommonHeader;
@@ -57,7 +57,7 @@ typedef struct BlitFragmentUniforms
     float height;
 
     Uint32 mip_level;
-    float layerOrDepth;
+    float layer_or_depth;
 } BlitFragmentUniforms;
 
 typedef struct BlitPipelineCacheEntry

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -694,7 +694,7 @@ struct SDL_GPUDevice
 
     // Store this for SDL_gpu.c's debug layer
     bool debug_mode;
-    SDL_GPUShaderFormat shaderFormats;
+    SDL_GPUShaderFormat shader_formats;
 };
 
 #define ASSIGN_DRIVER_FUNC(func, name) \
@@ -780,11 +780,11 @@ struct SDL_GPUDevice
 
 typedef struct SDL_GPUBootstrap
 {
-    const char *Name;
+    const char *name;
     const SDL_GPUDriver backendflag;
-    const SDL_GPUShaderFormat shaderFormats;
+    const SDL_GPUShaderFormat shader_formats;
     bool (*PrepareDriver)(SDL_VideoDevice *_this);
-    SDL_GPUDevice *(*CreateDevice)(bool debugMode, bool preferLowPower, SDL_PropertiesID props);
+    SDL_GPUDevice *(*CreateDevice)(bool debug_mode, bool prefer_low_power, SDL_PropertiesID props);
 } SDL_GPUBootstrap;
 
 #ifdef __cplusplus

--- a/src/gpu/clang-tidy-config
+++ b/src/gpu/clang-tidy-config
@@ -1,0 +1,7 @@
+Checks: "-*,readability-identifier-naming"
+CheckOptions:
+  readability-identifier-naming.ParameterCase: camelBack
+  readability-identifier-naming.LocalVariableCase: camelBack
+  readability-identifier-naming.LocalVariableIgnoredRegexp: "[A-Z]+.*"
+  readability-identifier-naming.MemberCase: camelBack
+  readability-identifier-naming.MemberIgnoredRegexp: "[A-Z]+.*|.*[dll].*"

--- a/src/gpu/clang-tidy-config
+++ b/src/gpu/clang-tidy-config
@@ -1,7 +1,0 @@
-Checks: "-*,readability-identifier-naming"
-CheckOptions:
-  readability-identifier-naming.ParameterCase: camelBack
-  readability-identifier-naming.LocalVariableCase: camelBack
-  readability-identifier-naming.LocalVariableIgnoredRegexp: "[A-Z]+.*"
-  readability-identifier-naming.MemberCase: camelBack
-  readability-identifier-naming.MemberIgnoredRegexp: "[A-Z]+.*|.*[dll].*"

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -5633,9 +5633,9 @@ static bool D3D11_SupportsTextureFormat(
 static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
 {
     void *d3d11_dll, *dxgi_dll;
-    PFN_D3D11_CREATE_DEVICE d3D11CreateDeviceFunc;
+    PFN_D3D11_CREATE_DEVICE D3D11CreateDeviceFunc;
     D3D_FEATURE_LEVEL levels[] = { D3D_FEATURE_LEVEL_11_1 };
-    PFN_CREATE_DXGI_FACTORY1 createDxgiFactoryFunc;
+    PFN_CREATE_DXGI_FACTORY1 CreateDxgiFactoryFunc;
     HRESULT res;
 
     // Can we load D3D11?
@@ -5646,10 +5646,10 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
         return false;
     }
 
-    d3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
+    D3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
         d3d11_dll,
         D3D11_CREATE_DEVICE_FUNC);
-    if (d3D11CreateDeviceFunc == NULL) {
+    if (D3D11CreateDeviceFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find function " D3D11_CREATE_DEVICE_FUNC " in " D3D11_DLL);
         SDL_UnloadObject(d3d11_dll);
         return false;
@@ -5657,7 +5657,7 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
 
     // Can we create a device?
 
-    res = d3D11CreateDeviceFunc(
+    res = D3D11CreateDeviceFunc(
         NULL,
         D3D_DRIVER_TYPE_HARDWARE,
         NULL,
@@ -5684,11 +5684,11 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
         return false;
     }
 
-    createDxgiFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
+    CreateDxgiFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
         dxgi_dll,
         CREATE_DXGI_FACTORY1_FUNC);
     SDL_UnloadObject(dxgi_dll); // We're not going to call this function, so we can just unload now.
-    if (createDxgiFactoryFunc == NULL) {
+    if (CreateDxgiFactoryFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find function " CREATE_DXGI_FACTORY1_FUNC " in " DXGI_DLL);
         return false;
     }
@@ -5698,7 +5698,7 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
 
 static void D3D11_INTERNAL_TryInitializeDXGIDebug(D3D11Renderer *renderer)
 {
-    PFN_DXGI_GET_DEBUG_INTERFACE dxgiGetDebugInterfaceFunc;
+    PFN_DXGI_GET_DEBUG_INTERFACE DXGIGetDebugInterfaceFunc;
     HRESULT res;
 
     renderer->dxgidebug_dll = SDL_LoadObject(DXGIDEBUG_DLL);
@@ -5707,21 +5707,21 @@ static void D3D11_INTERNAL_TryInitializeDXGIDebug(D3D11Renderer *renderer)
         return;
     }
 
-    dxgiGetDebugInterfaceFunc = (PFN_DXGI_GET_DEBUG_INTERFACE)SDL_LoadFunction(
+    DXGIGetDebugInterfaceFunc = (PFN_DXGI_GET_DEBUG_INTERFACE)SDL_LoadFunction(
         renderer->dxgidebug_dll,
         DXGI_GET_DEBUG_INTERFACE_FUNC);
-    if (dxgiGetDebugInterfaceFunc == NULL) {
+    if (DXGIGetDebugInterfaceFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not load function: " DXGI_GET_DEBUG_INTERFACE_FUNC);
         return;
     }
 
-    res = dxgiGetDebugInterfaceFunc(&D3D_IID_IDXGIDebug, (void **)&renderer->dxgiDebug);
+    res = DXGIGetDebugInterfaceFunc(&D3D_IID_IDXGIDebug, (void **)&renderer->dxgiDebug);
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not get IDXGIDebug interface");
     }
 
 #ifdef HAVE_IDXGIINFOQUEUE
-    res = dxgiGetDebugInterfaceFunc(&D3D_IID_IDXGIInfoQueue, (void **)&renderer->dxgiInfoQueue);
+    res = DXGIGetDebugInterfaceFunc(&D3D_IID_IDXGIInfoQueue, (void **)&renderer->dxgiInfoQueue);
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not get IDXGIInfoQueue interface");
     }
@@ -5938,8 +5938,8 @@ static void D3D11_INTERNAL_DestroyBlitPipelines(
 static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
 {
     D3D11Renderer *renderer;
-    PFN_CREATE_DXGI_FACTORY1 createDxgiFactoryFunc;
-    PFN_D3D11_CREATE_DEVICE d3D11CreateDeviceFunc;
+    PFN_CREATE_DXGI_FACTORY1 CreateDxgiFactoryFunc;
+    PFN_D3D11_CREATE_DEVICE D3D11CreateDeviceFunc;
     D3D_FEATURE_LEVEL levels[] = { D3D_FEATURE_LEVEL_11_1 };
     IDXGIFactory4 *factory4;
     IDXGIFactory5 *factory5;
@@ -5960,16 +5960,16 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SD
     }
 
     // Load the CreateDXGIFactory1 function
-    createDxgiFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
+    CreateDxgiFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
         renderer->dxgi_dll,
         CREATE_DXGI_FACTORY1_FUNC);
-    if (createDxgiFactoryFunc == NULL) {
+    if (CreateDxgiFactoryFunc == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not load function: " CREATE_DXGI_FACTORY1_FUNC);
         return NULL;
     }
 
     // Create the DXGI factory
-    res = createDxgiFactoryFunc(
+    res = CreateDxgiFactoryFunc(
         &D3D_IID_IDXGIFactory1,
         (void **)&renderer->factory);
     ERROR_CHECK_RETURN("Could not create DXGIFactory", NULL);
@@ -6037,10 +6037,10 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SD
     }
 
     // Load the CreateDevice function
-    d3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
+    D3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
         renderer->d3d11_dll,
         D3D11_CREATE_DEVICE_FUNC);
-    if (d3D11CreateDeviceFunc == NULL) {
+    if (D3D11CreateDeviceFunc == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not load function: " D3D11_CREATE_DEVICE_FUNC);
         return NULL;
     }
@@ -6054,7 +6054,7 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SD
     // Create the device
     ID3D11Device *d3d11Device;
 tryCreateDevice:
-    res = d3D11CreateDeviceFunc(
+    res = D3D11CreateDeviceFunc(
         (IDXGIAdapter *)renderer->adapter,
         D3D_DRIVER_TYPE_UNKNOWN, // Must be UNKNOWN if adapter is non-null according to spec
         NULL,

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -706,9 +706,9 @@ struct D3D11Renderer
     IDXGIInfoQueue *dxgiInfoQueue;
 #endif
 
-    void *d3d11Dll;
-    void *dxgiDll;
-    void *dxgidebugDll;
+    void *d3d11_dll;
+    void *dxgi_dll;
+    void *dxgidebug_dll;
 
     Uint8 debugMode;
     BOOL supportsTearing;
@@ -986,10 +986,10 @@ static void D3D11_DestroyDevice(
 #endif
 
     // Release the DLLs
-    SDL_UnloadObject(renderer->d3d11Dll);
-    SDL_UnloadObject(renderer->dxgiDll);
-    if (renderer->dxgidebugDll) {
-        SDL_UnloadObject(renderer->dxgidebugDll);
+    SDL_UnloadObject(renderer->d3d11_dll);
+    SDL_UnloadObject(renderer->dxgi_dll);
+    if (renderer->dxgidebug_dll) {
+        SDL_UnloadObject(renderer->dxgidebug_dll);
     }
 
     // Free the primary structures
@@ -5632,7 +5632,7 @@ static bool D3D11_SupportsTextureFormat(
 
 static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
 {
-    void *d3d11Dll, *dxgiDll;
+    void *d3d11_dll, *dxgi_dll;
     PFN_D3D11_CREATE_DEVICE d3D11CreateDeviceFunc;
     D3D_FEATURE_LEVEL levels[] = { D3D_FEATURE_LEVEL_11_1 };
     PFN_CREATE_DXGI_FACTORY1 createDxgiFactoryFunc;
@@ -5640,18 +5640,18 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
 
     // Can we load D3D11?
 
-    d3d11Dll = SDL_LoadObject(D3D11_DLL);
-    if (d3d11Dll == NULL) {
+    d3d11_dll = SDL_LoadObject(D3D11_DLL);
+    if (d3d11_dll == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find " D3D11_DLL);
         return false;
     }
 
     d3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
-        d3d11Dll,
+        d3d11_dll,
         D3D11_CREATE_DEVICE_FUNC);
     if (d3D11CreateDeviceFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find function " D3D11_CREATE_DEVICE_FUNC " in " D3D11_DLL);
-        SDL_UnloadObject(d3d11Dll);
+        SDL_UnloadObject(d3d11_dll);
         return false;
     }
 
@@ -5669,7 +5669,7 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
         NULL,
         NULL);
 
-    SDL_UnloadObject(d3d11Dll);
+    SDL_UnloadObject(d3d11_dll);
 
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not create D3D11Device with feature level 11_1");
@@ -5678,16 +5678,16 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
 
     // Can we load DXGI?
 
-    dxgiDll = SDL_LoadObject(DXGI_DLL);
-    if (dxgiDll == NULL) {
+    dxgi_dll = SDL_LoadObject(DXGI_DLL);
+    if (dxgi_dll == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find " DXGI_DLL);
         return false;
     }
 
     createDxgiFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
-        dxgiDll,
+        dxgi_dll,
         CREATE_DXGI_FACTORY1_FUNC);
-    SDL_UnloadObject(dxgiDll); // We're not going to call this function, so we can just unload now.
+    SDL_UnloadObject(dxgi_dll); // We're not going to call this function, so we can just unload now.
     if (createDxgiFactoryFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find function " CREATE_DXGI_FACTORY1_FUNC " in " DXGI_DLL);
         return false;
@@ -5701,14 +5701,14 @@ static void D3D11_INTERNAL_TryInitializeDXGIDebug(D3D11Renderer *renderer)
     PFN_DXGI_GET_DEBUG_INTERFACE dxgiGetDebugInterfaceFunc;
     HRESULT res;
 
-    renderer->dxgidebugDll = SDL_LoadObject(DXGIDEBUG_DLL);
-    if (renderer->dxgidebugDll == NULL) {
+    renderer->dxgidebug_dll = SDL_LoadObject(DXGIDEBUG_DLL);
+    if (renderer->dxgidebug_dll == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not find " DXGIDEBUG_DLL);
         return;
     }
 
     dxgiGetDebugInterfaceFunc = (PFN_DXGI_GET_DEBUG_INTERFACE)SDL_LoadFunction(
-        renderer->dxgidebugDll,
+        renderer->dxgidebug_dll,
         DXGI_GET_DEBUG_INTERFACE_FUNC);
     if (dxgiGetDebugInterfaceFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not load function: " DXGI_GET_DEBUG_INTERFACE_FUNC);
@@ -5953,15 +5953,15 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SD
     renderer = (D3D11Renderer *)SDL_calloc(1, sizeof(D3D11Renderer));
 
     // Load the DXGI library
-    renderer->dxgiDll = SDL_LoadObject(DXGI_DLL);
-    if (renderer->dxgiDll == NULL) {
+    renderer->dxgi_dll = SDL_LoadObject(DXGI_DLL);
+    if (renderer->dxgi_dll == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not find " DXGI_DLL);
         return NULL;
     }
 
     // Load the CreateDXGIFactory1 function
     createDxgiFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
-        renderer->dxgiDll,
+        renderer->dxgi_dll,
         CREATE_DXGI_FACTORY1_FUNC);
     if (createDxgiFactoryFunc == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not load function: " CREATE_DXGI_FACTORY1_FUNC);
@@ -6030,15 +6030,15 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SD
     }
 
     // Load the D3D library
-    renderer->d3d11Dll = SDL_LoadObject(D3D11_DLL);
-    if (renderer->d3d11Dll == NULL) {
+    renderer->d3d11_dll = SDL_LoadObject(D3D11_DLL);
+    if (renderer->d3d11_dll == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not find " D3D11_DLL);
         return NULL;
     }
 
     // Load the CreateDevice function
     d3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
-        renderer->d3d11Dll,
+        renderer->d3d11_dll,
         D3D11_CREATE_DEVICE_FUNC);
     if (d3D11CreateDeviceFunc == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not load function: " D3D11_CREATE_DEVICE_FUNC);

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -454,8 +454,8 @@ typedef struct D3D11WindowData
     IDXGISwapChain *swapchain;
     D3D11Texture texture;
     D3D11TextureContainer textureContainer;
-    SDL_GPUPresentMode present_mode;
-    SDL_GPUSwapchainComposition swapchain_composition;
+    SDL_GPUPresentMode presentMode;
+    SDL_GPUSwapchainComposition swapchainComposition;
     DXGI_FORMAT swapchainFormat;
     DXGI_COLOR_SPACE_TYPE swapchainColorSpace;
     SDL_GPUFence *inFlightFences[MAX_FRAMES_IN_FLIGHT];
@@ -468,10 +468,10 @@ typedef struct D3D11Shader
     void *bytecode;
     size_t bytecodeSize;
 
-    Uint32 num_samplers;
-    Uint32 num_uniform_buffers;
-    Uint32 num_storage_buffers;
-    Uint32 num_storage_textures;
+    Uint32 numSamplers;
+    Uint32 numUniformBuffers;
+    Uint32 numStorageBuffers;
+    Uint32 numStorageTextures;
 } D3D11Shader;
 
 typedef struct D3D11GraphicsPipeline
@@ -480,17 +480,17 @@ typedef struct D3D11GraphicsPipeline
     DXGI_FORMAT colorAttachmentFormats[MAX_COLOR_TARGET_BINDINGS];
     ID3D11BlendState *colorAttachmentBlendState;
 
-    SDL_GPUMultisampleState multisample_state;
+    SDL_GPUMultisampleState multisampleState;
 
-    Uint8 has_depth_stencil_attachment;
+    Uint8 hasDepthStencilAttachment;
     DXGI_FORMAT depthStencilAttachmentFormat;
-    ID3D11DepthStencilState *depth_stencil_state;
+    ID3D11DepthStencilState *depthStencilState;
 
-    SDL_GPUPrimitiveType primitive_type;
-    ID3D11RasterizerState *rasterizer_state;
+    SDL_GPUPrimitiveType primitiveType;
+    ID3D11RasterizerState *rasterizerState;
 
-    ID3D11VertexShader *vertex_shader;
-    ID3D11PixelShader *fragment_shader;
+    ID3D11VertexShader *vertexShader;
+    ID3D11PixelShader *fragmentShader;
 
     ID3D11InputLayout *inputLayout;
     Uint32 *vertexStrides;
@@ -510,11 +510,11 @@ typedef struct D3D11ComputePipeline
 {
     ID3D11ComputeShader *computeShader;
 
-    Uint32 num_readonly_storage_textures;
-    Uint32 num_writeonly_storage_textures;
-    Uint32 num_readonly_storage_buffers;
-    Uint32 num_writeonly_storage_buffers;
-    Uint32 num_uniform_buffers;
+    Uint32 numReadonlyStorageTextures;
+    Uint32 numWriteonlyStorageTextures;
+    Uint32 numReadonlyStorageBuffers;
+    Uint32 numWriteonlyStorageBuffers;
+    Uint32 numUniformBuffers;
 } D3D11ComputePipeline;
 
 typedef struct D3D11Buffer
@@ -612,9 +612,9 @@ typedef struct D3D11CommandBuffer
     Uint32 windowDataCapacity;
 
     // Render Pass
-    D3D11GraphicsPipeline *graphics_pipeline;
+    D3D11GraphicsPipeline *graphicsPipeline;
     Uint8 stencilRef;
-    SDL_FColor blend_constants;
+    SDL_FColor blendConstants;
 
     // Render Pass MSAA resolve
     D3D11Texture *colorTargetResolveTexture[MAX_COLOR_TARGET_BINDINGS];
@@ -623,7 +623,7 @@ typedef struct D3D11CommandBuffer
     DXGI_FORMAT colorTargetMsaaFormat[MAX_COLOR_TARGET_BINDINGS];
 
     // Compute Pass
-    D3D11ComputePipeline *compute_pipeline;
+    D3D11ComputePipeline *computePipeline;
 
     // Debug Annotation
     ID3DUserDefinedAnnotation *annotation;
@@ -706,11 +706,11 @@ struct D3D11Renderer
     IDXGIInfoQueue *dxgiInfoQueue;
 #endif
 
-    void *d3d11_dll;
-    void *dxgi_dll;
-    void *dxgidebug_dll;
+    void *d3d11Dll;
+    void *dxgiDll;
+    void *dxgidebugDll;
 
-    Uint8 debug_mode;
+    Uint8 debugMode;
     BOOL supportsTearing;
     Uint8 supportsFlipDiscard;
 
@@ -833,11 +833,11 @@ static void D3D11_INTERNAL_LogError(
 // Helper Functions
 
 static inline Uint32 D3D11_INTERNAL_CalcSubresource(
-    Uint32 mip_level,
+    Uint32 mipLevel,
     Uint32 layer,
     Uint32 numLevels)
 {
-    return mip_level + (layer * numLevels);
+    return mipLevel + (layer * numLevels);
 }
 
 static inline Uint32 D3D11_INTERNAL_NextHighestAlignment(
@@ -932,14 +932,14 @@ static void D3D11_DestroyDevice(
 
     // Release command buffer infrastructure
     for (Uint32 i = 0; i < renderer->availableCommandBufferCount; i += 1) {
-        D3D11CommandBuffer *command_buffer = renderer->availableCommandBuffers[i];
-        if (command_buffer->annotation) {
-            ID3DUserDefinedAnnotation_Release(command_buffer->annotation);
+        D3D11CommandBuffer *commandBuffer = renderer->availableCommandBuffers[i];
+        if (commandBuffer->annotation) {
+            ID3DUserDefinedAnnotation_Release(commandBuffer->annotation);
         }
-        ID3D11DeviceContext_Release(command_buffer->context);
-        SDL_free(command_buffer->usedBuffers);
-        SDL_free(command_buffer->usedTransferBuffers);
-        SDL_free(command_buffer);
+        ID3D11DeviceContext_Release(commandBuffer->context);
+        SDL_free(commandBuffer->usedBuffers);
+        SDL_free(commandBuffer->usedTransferBuffers);
+        SDL_free(commandBuffer);
     }
     SDL_free(renderer->availableCommandBuffers);
     SDL_free(renderer->submittedCommandBuffers);
@@ -986,10 +986,10 @@ static void D3D11_DestroyDevice(
 #endif
 
     // Release the DLLs
-    SDL_UnloadObject(renderer->d3d11_dll);
-    SDL_UnloadObject(renderer->dxgi_dll);
-    if (renderer->dxgidebug_dll) {
-        SDL_UnloadObject(renderer->dxgidebug_dll);
+    SDL_UnloadObject(renderer->d3d11Dll);
+    SDL_UnloadObject(renderer->dxgiDll);
+    if (renderer->dxgidebugDll) {
+        SDL_UnloadObject(renderer->dxgidebugDll);
     }
 
     // Free the primary structures
@@ -1036,25 +1036,25 @@ static void D3D11_INTERNAL_TrackTexture(
 }
 
 static void D3D11_INTERNAL_TrackUniformBuffer(
-    D3D11CommandBuffer *command_buffer,
+    D3D11CommandBuffer *commandBuffer,
     D3D11UniformBuffer *uniformBuffer)
 {
     Uint32 i;
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
-        if (command_buffer->usedUniformBuffers[i] == uniformBuffer) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
+        if (commandBuffer->usedUniformBuffers[i] == uniformBuffer) {
             return;
         }
     }
 
-    if (command_buffer->usedUniformBufferCount == command_buffer->usedUniformBufferCapacity) {
-        command_buffer->usedUniformBufferCapacity += 1;
-        command_buffer->usedUniformBuffers = SDL_realloc(
-            command_buffer->usedUniformBuffers,
-            command_buffer->usedUniformBufferCapacity * sizeof(D3D11UniformBuffer *));
+    if (commandBuffer->usedUniformBufferCount == commandBuffer->usedUniformBufferCapacity) {
+        commandBuffer->usedUniformBufferCapacity += 1;
+        commandBuffer->usedUniformBuffers = SDL_realloc(
+            commandBuffer->usedUniformBuffers,
+            commandBuffer->usedUniformBufferCapacity * sizeof(D3D11UniformBuffer *));
     }
 
-    command_buffer->usedUniformBuffers[command_buffer->usedUniformBufferCount] = uniformBuffer;
-    command_buffer->usedUniformBufferCount += 1;
+    commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
+    commandBuffer->usedUniformBufferCount += 1;
 }
 
 // Disposal
@@ -1161,7 +1161,7 @@ static void D3D11_ReleaseBuffer(
 
 static void D3D11_ReleaseTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
 
@@ -1174,7 +1174,7 @@ static void D3D11_ReleaseTransferBuffer(
         renderer->transferBufferContainersToDestroyCapacity,
         renderer->transferBufferContainersToDestroyCapacity + 1);
 
-    renderer->transferBufferContainersToDestroy[renderer->transferBufferContainersToDestroyCount] = (D3D11TransferBufferContainer *)transfer_buffer;
+    renderer->transferBufferContainersToDestroy[renderer->transferBufferContainersToDestroyCount] = (D3D11TransferBufferContainer *)transferBuffer;
     renderer->transferBufferContainersToDestroyCount += 1;
 
     SDL_UnlockMutex(renderer->contextLock);
@@ -1211,9 +1211,9 @@ static void D3D11_ReleaseShader(
 
 static void D3D11_ReleaseComputePipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUComputePipeline *computePipeline)
 {
-    D3D11ComputePipeline *d3d11ComputePipeline = (D3D11ComputePipeline *)compute_pipeline;
+    D3D11ComputePipeline *d3d11ComputePipeline = (D3D11ComputePipeline *)computePipeline;
 
     ID3D11ComputeShader_Release(d3d11ComputePipeline->computeShader);
 
@@ -1222,14 +1222,14 @@ static void D3D11_ReleaseComputePipeline(
 
 static void D3D11_ReleaseGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
     (void)driverData; // used by other backends
-    D3D11GraphicsPipeline *d3d11GraphicsPipeline = (D3D11GraphicsPipeline *)graphics_pipeline;
+    D3D11GraphicsPipeline *d3d11GraphicsPipeline = (D3D11GraphicsPipeline *)graphicsPipeline;
 
     ID3D11BlendState_Release(d3d11GraphicsPipeline->colorAttachmentBlendState);
-    ID3D11DepthStencilState_Release(d3d11GraphicsPipeline->depth_stencil_state);
-    ID3D11RasterizerState_Release(d3d11GraphicsPipeline->rasterizer_state);
+    ID3D11DepthStencilState_Release(d3d11GraphicsPipeline->depthStencilState);
+    ID3D11RasterizerState_Release(d3d11GraphicsPipeline->rasterizerState);
 
     if (d3d11GraphicsPipeline->inputLayout) {
         ID3D11InputLayout_Release(d3d11GraphicsPipeline->inputLayout);
@@ -1238,8 +1238,8 @@ static void D3D11_ReleaseGraphicsPipeline(
         SDL_free(d3d11GraphicsPipeline->vertexStrides);
     }
 
-    ID3D11VertexShader_Release(d3d11GraphicsPipeline->vertex_shader);
-    ID3D11PixelShader_Release(d3d11GraphicsPipeline->fragment_shader);
+    ID3D11VertexShader_Release(d3d11GraphicsPipeline->vertexShader);
+    ID3D11PixelShader_Release(d3d11GraphicsPipeline->fragmentShader);
 
     SDL_free(d3d11GraphicsPipeline);
 }
@@ -1285,7 +1285,7 @@ static ID3D11BlendState *D3D11_INTERNAL_FetchBlendState(
 
 static ID3D11DepthStencilState *D3D11_INTERNAL_FetchDepthStencilState(
     D3D11Renderer *renderer,
-    SDL_GPUDepthStencilState depth_stencil_state)
+    SDL_GPUDepthStencilState depthStencilState)
 {
     ID3D11DepthStencilState *result;
     D3D11_DEPTH_STENCIL_DESC dsDesc;
@@ -1294,23 +1294,23 @@ static ID3D11DepthStencilState *D3D11_INTERNAL_FetchDepthStencilState(
     /* Create a new depth-stencil state.
      * The spec says the driver will not create duplicate states, so there's no need to cache.
      */
-    dsDesc.DepthEnable = depth_stencil_state.enable_depth_test;
-    dsDesc.StencilEnable = depth_stencil_state.enable_stencil_test;
-    dsDesc.DepthFunc = SDLToD3D11_CompareOp[depth_stencil_state.compare_op];
-    dsDesc.DepthWriteMask = (depth_stencil_state.enable_depth_write ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO);
+    dsDesc.DepthEnable = depthStencilState.enable_depth_test;
+    dsDesc.StencilEnable = depthStencilState.enable_stencil_test;
+    dsDesc.DepthFunc = SDLToD3D11_CompareOp[depthStencilState.compare_op];
+    dsDesc.DepthWriteMask = (depthStencilState.enable_depth_write ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO);
 
-    dsDesc.BackFace.StencilFunc = SDLToD3D11_CompareOp[depth_stencil_state.back_stencil_state.compare_op];
-    dsDesc.BackFace.StencilDepthFailOp = SDLToD3D11_StencilOp[depth_stencil_state.back_stencil_state.depth_fail_op];
-    dsDesc.BackFace.StencilFailOp = SDLToD3D11_StencilOp[depth_stencil_state.back_stencil_state.fail_op];
-    dsDesc.BackFace.StencilPassOp = SDLToD3D11_StencilOp[depth_stencil_state.back_stencil_state.pass_op];
+    dsDesc.BackFace.StencilFunc = SDLToD3D11_CompareOp[depthStencilState.back_stencil_state.compare_op];
+    dsDesc.BackFace.StencilDepthFailOp = SDLToD3D11_StencilOp[depthStencilState.back_stencil_state.depth_fail_op];
+    dsDesc.BackFace.StencilFailOp = SDLToD3D11_StencilOp[depthStencilState.back_stencil_state.fail_op];
+    dsDesc.BackFace.StencilPassOp = SDLToD3D11_StencilOp[depthStencilState.back_stencil_state.pass_op];
 
-    dsDesc.FrontFace.StencilFunc = SDLToD3D11_CompareOp[depth_stencil_state.front_stencil_state.compare_op];
-    dsDesc.FrontFace.StencilDepthFailOp = SDLToD3D11_StencilOp[depth_stencil_state.front_stencil_state.depth_fail_op];
-    dsDesc.FrontFace.StencilFailOp = SDLToD3D11_StencilOp[depth_stencil_state.front_stencil_state.fail_op];
-    dsDesc.FrontFace.StencilPassOp = SDLToD3D11_StencilOp[depth_stencil_state.front_stencil_state.pass_op];
+    dsDesc.FrontFace.StencilFunc = SDLToD3D11_CompareOp[depthStencilState.front_stencil_state.compare_op];
+    dsDesc.FrontFace.StencilDepthFailOp = SDLToD3D11_StencilOp[depthStencilState.front_stencil_state.depth_fail_op];
+    dsDesc.FrontFace.StencilFailOp = SDLToD3D11_StencilOp[depthStencilState.front_stencil_state.fail_op];
+    dsDesc.FrontFace.StencilPassOp = SDLToD3D11_StencilOp[depthStencilState.front_stencil_state.pass_op];
 
-    dsDesc.StencilReadMask = depth_stencil_state.compare_mask;
-    dsDesc.StencilWriteMask = depth_stencil_state.write_mask;
+    dsDesc.StencilReadMask = depthStencilState.compare_mask;
+    dsDesc.StencilWriteMask = depthStencilState.write_mask;
 
     res = ID3D11Device_CreateDepthStencilState(
         renderer->device,
@@ -1323,7 +1323,7 @@ static ID3D11DepthStencilState *D3D11_INTERNAL_FetchDepthStencilState(
 
 static ID3D11RasterizerState *D3D11_INTERNAL_FetchRasterizerState(
     D3D11Renderer *renderer,
-    SDL_GPURasterizerState rasterizer_state)
+    SDL_GPURasterizerState rasterizerState)
 {
     ID3D11RasterizerState *result;
     D3D11_RASTERIZER_DESC rasterizerDesc;
@@ -1333,15 +1333,15 @@ static ID3D11RasterizerState *D3D11_INTERNAL_FetchRasterizerState(
      * The spec says the driver will not create duplicate states, so there's no need to cache.
      */
     rasterizerDesc.AntialiasedLineEnable = FALSE;
-    rasterizerDesc.CullMode = SDLToD3D11_CullMode[rasterizer_state.cull_mode];
-    rasterizerDesc.DepthBias = SDL_lroundf(rasterizer_state.depth_bias_constant_factor);
-    rasterizerDesc.DepthBiasClamp = rasterizer_state.depth_bias_clamp;
+    rasterizerDesc.CullMode = SDLToD3D11_CullMode[rasterizerState.cull_mode];
+    rasterizerDesc.DepthBias = SDL_lroundf(rasterizerState.depth_bias_constant_factor);
+    rasterizerDesc.DepthBiasClamp = rasterizerState.depth_bias_clamp;
     rasterizerDesc.DepthClipEnable = TRUE;
-    rasterizerDesc.FillMode = (rasterizer_state.fill_mode == SDL_GPU_FILLMODE_FILL) ? D3D11_FILL_SOLID : D3D11_FILL_WIREFRAME;
-    rasterizerDesc.FrontCounterClockwise = (rasterizer_state.frontFace == SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE);
+    rasterizerDesc.FillMode = (rasterizerState.fill_mode == SDL_GPU_FILLMODE_FILL) ? D3D11_FILL_SOLID : D3D11_FILL_WIREFRAME;
+    rasterizerDesc.FrontCounterClockwise = (rasterizerState.frontFace == SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE);
     rasterizerDesc.MultisampleEnable = TRUE; // only applies to MSAA render targets
     rasterizerDesc.ScissorEnable = TRUE;
-    rasterizerDesc.SlopeScaledDepthBias = rasterizer_state.depth_bias_slope_factor;
+    rasterizerDesc.SlopeScaledDepthBias = rasterizerState.depth_bias_slope_factor;
 
     res = ID3D11Device_CreateRasterizerState(
         renderer->device,
@@ -1434,8 +1434,8 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
     D3D11Renderer *renderer,
     Uint32 stage,
     const Uint8 *code,
-    size_t code_size,
-    const char *entrypoint_name,
+    size_t codeSize,
+    const char *entrypointName,
     void **pBytecode,
     size_t *pBytecodeSize)
 {
@@ -1447,7 +1447,7 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
         res = ID3D11Device_CreateVertexShader(
             renderer->device,
             code,
-            code_size,
+            codeSize,
             NULL,
             (ID3D11VertexShader **)&handle);
         if (FAILED(res)) {
@@ -1458,7 +1458,7 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
         res = ID3D11Device_CreatePixelShader(
             renderer->device,
             code,
-            code_size,
+            codeSize,
             NULL,
             (ID3D11PixelShader **)&handle);
         if (FAILED(res)) {
@@ -1469,7 +1469,7 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
         res = ID3D11Device_CreateComputeShader(
             renderer->device,
             code,
-            code_size,
+            codeSize,
             NULL,
             (ID3D11ComputeShader **)&handle);
         if (FAILED(res)) {
@@ -1479,9 +1479,9 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
     }
 
     if (pBytecode != NULL) {
-        *pBytecode = SDL_malloc(code_size);
-        SDL_memcpy(*pBytecode, code, code_size);
-        *pBytecodeSize = code_size;
+        *pBytecode = SDL_malloc(codeSize);
+        SDL_memcpy(*pBytecode, code, codeSize);
+        *pBytecodeSize = codeSize;
     }
 
     return handle;
@@ -1510,11 +1510,11 @@ static SDL_GPUComputePipeline *D3D11_CreateComputePipeline(
 
     pipeline = SDL_malloc(sizeof(D3D11ComputePipeline));
     pipeline->computeShader = shader;
-    pipeline->num_readonly_storage_textures = createinfo->num_readonly_storage_textures;
-    pipeline->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
-    pipeline->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
-    pipeline->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
-    pipeline->num_uniform_buffers = createinfo->num_uniform_buffers;
+    pipeline->numReadonlyStorageTextures = createinfo->num_readonly_storage_textures;
+    pipeline->numWriteonlyStorageTextures = createinfo->num_writeonly_storage_textures;
+    pipeline->numReadonlyStorageBuffers = createinfo->num_readonly_storage_buffers;
+    pipeline->numWriteonlyStorageBuffers = createinfo->num_writeonly_storage_buffers;
+    pipeline->numUniformBuffers = createinfo->num_uniform_buffers;
     // thread counts are ignored in d3d11
 
     return (SDL_GPUComputePipeline *)pipeline;
@@ -1543,31 +1543,31 @@ static SDL_GPUGraphicsPipeline *D3D11_CreateGraphicsPipeline(
 
     // Multisample
 
-    pipeline->multisample_state = createinfo->multisample_state;
+    pipeline->multisampleState = createinfo->multisample_state;
 
     // Depth-Stencil
 
-    pipeline->depth_stencil_state = D3D11_INTERNAL_FetchDepthStencilState(
+    pipeline->depthStencilState = D3D11_INTERNAL_FetchDepthStencilState(
         renderer,
         createinfo->depth_stencil_state);
 
-    pipeline->has_depth_stencil_attachment = createinfo->attachment_info.has_depth_stencil_attachment;
+    pipeline->hasDepthStencilAttachment = createinfo->attachment_info.has_depth_stencil_attachment;
     pipeline->depthStencilAttachmentFormat = SDLToD3D11_TextureFormat[createinfo->attachment_info.depth_stencil_format];
 
     // Rasterizer
 
-    pipeline->primitive_type = createinfo->primitive_type;
-    pipeline->rasterizer_state = D3D11_INTERNAL_FetchRasterizerState(
+    pipeline->primitiveType = createinfo->primitive_type;
+    pipeline->rasterizerState = D3D11_INTERNAL_FetchRasterizerState(
         renderer,
         createinfo->rasterizer_state);
 
     // Shaders
 
-    pipeline->vertex_shader = (ID3D11VertexShader *)vertShader->handle;
-    ID3D11VertexShader_AddRef(pipeline->vertex_shader);
+    pipeline->vertexShader = (ID3D11VertexShader *)vertShader->handle;
+    ID3D11VertexShader_AddRef(pipeline->vertexShader);
 
-    pipeline->fragment_shader = (ID3D11PixelShader *)fragShader->handle;
-    ID3D11PixelShader_AddRef(pipeline->fragment_shader);
+    pipeline->fragmentShader = (ID3D11PixelShader *)fragShader->handle;
+    ID3D11PixelShader_AddRef(pipeline->fragmentShader);
 
     // Input Layout
 
@@ -1591,15 +1591,15 @@ static SDL_GPUGraphicsPipeline *D3D11_CreateGraphicsPipeline(
 
     // Resource layout
 
-    pipeline->vertexSamplerCount = vertShader->num_samplers;
-    pipeline->vertexStorageTextureCount = vertShader->num_storage_textures;
-    pipeline->vertexStorageBufferCount = vertShader->num_storage_buffers;
-    pipeline->vertexUniformBufferCount = vertShader->num_uniform_buffers;
+    pipeline->vertexSamplerCount = vertShader->numSamplers;
+    pipeline->vertexStorageTextureCount = vertShader->numStorageTextures;
+    pipeline->vertexStorageBufferCount = vertShader->numStorageBuffers;
+    pipeline->vertexUniformBufferCount = vertShader->numUniformBuffers;
 
-    pipeline->fragmentSamplerCount = fragShader->num_samplers;
-    pipeline->fragmentStorageTextureCount = fragShader->num_storage_textures;
-    pipeline->fragmentStorageBufferCount = fragShader->num_storage_buffers;
-    pipeline->fragmentUniformBufferCount = fragShader->num_uniform_buffers;
+    pipeline->fragmentSamplerCount = fragShader->numSamplers;
+    pipeline->fragmentStorageTextureCount = fragShader->numStorageTextures;
+    pipeline->fragmentStorageBufferCount = fragShader->numStorageBuffers;
+    pipeline->fragmentUniformBufferCount = fragShader->numUniformBuffers;
 
     return (SDL_GPUGraphicsPipeline *)pipeline;
 }
@@ -1611,7 +1611,7 @@ static void D3D11_INTERNAL_SetBufferName(
     D3D11Buffer *buffer,
     const char *text)
 {
-    if (renderer->debug_mode) {
+    if (renderer->debugMode) {
         ID3D11DeviceChild_SetPrivateData(
             buffer->handle,
             &D3D_IID_D3DDebugObjectName,
@@ -1629,7 +1629,7 @@ static void D3D11_SetBufferName(
     D3D11BufferContainer *container = (D3D11BufferContainer *)buffer;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debug_mode) {
+    if (renderer->debugMode) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -1653,7 +1653,7 @@ static void D3D11_INTERNAL_SetTextureName(
     D3D11Texture *texture,
     const char *text)
 {
-    if (renderer->debug_mode) {
+    if (renderer->debugMode) {
         ID3D11DeviceChild_SetPrivateData(
             texture->handle,
             &D3D_IID_D3DDebugObjectName,
@@ -1671,7 +1671,7 @@ static void D3D11_SetTextureName(
     D3D11TextureContainer *container = (D3D11TextureContainer *)texture;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debug_mode) {
+    if (renderer->debugMode) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -1694,10 +1694,10 @@ static bool D3D11_INTERNAL_StrToWStr(
     D3D11Renderer *renderer,
     const char *str,
     wchar_t *wstr,
-    size_t wstr_size)
+    size_t wstrSize)
 {
     size_t inlen, result;
-    size_t outlen = wstr_size;
+    size_t outlen = wstrSize;
 
     if (renderer->iconv == NULL) {
         renderer->iconv = SDL_iconv_open("WCHAR_T", "UTF-8");
@@ -1729,10 +1729,10 @@ static bool D3D11_INTERNAL_StrToWStr(
 }
 
 static void D3D11_InsertDebugLabel(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *text)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
 
     if (d3d11CommandBuffer->annotation == NULL) {
@@ -1748,10 +1748,10 @@ static void D3D11_InsertDebugLabel(
 }
 
 static void D3D11_PushDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *name)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
 
     if (d3d11CommandBuffer->annotation == NULL) {
@@ -1767,9 +1767,9 @@ static void D3D11_PushDebugGroup(
 }
 
 static void D3D11_PopDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     if (d3d11CommandBuffer->annotation == NULL) {
         return;
     }
@@ -1835,10 +1835,10 @@ SDL_GPUShader *D3D11_CreateShader(
 
     shader = (D3D11Shader *)SDL_calloc(1, sizeof(D3D11Shader));
     shader->handle = handle;
-    shader->num_samplers = createinfo->num_samplers;
-    shader->num_storage_buffers = createinfo->num_storage_buffers;
-    shader->num_storage_textures = createinfo->num_storage_textures;
-    shader->num_uniform_buffers = createinfo->num_uniform_buffers;
+    shader->numSamplers = createinfo->num_samplers;
+    shader->numStorageBuffers = createinfo->num_storage_buffers;
+    shader->numStorageTextures = createinfo->num_storage_textures;
+    shader->numUniformBuffers = createinfo->num_uniform_buffers;
     if (createinfo->stage == SDL_GPU_SHADERSTAGE_VERTEX) {
         // Store the raw bytecode and its length for creating InputLayouts
         shader->bytecode = bytecode;
@@ -2165,7 +2165,7 @@ static D3D11Texture *D3D11_INTERNAL_CreateTexture(
 static bool D3D11_SupportsSampleCount(
     SDL_GPURenderer *driverData,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sample_count)
+    SDL_GPUSampleCount sampleCount)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     Uint32 levels;
@@ -2173,7 +2173,7 @@ static bool D3D11_SupportsSampleCount(
     HRESULT res = ID3D11Device_CheckMultisampleQualityLevels(
         renderer->device,
         SDLToD3D11_TextureFormat[format],
-        SDLToD3D11_SampleCount[sample_count],
+        SDLToD3D11_SampleCount[sampleCount],
         &levels);
 
     return SUCCEEDED(res) && levels > 0;
@@ -2250,7 +2250,7 @@ static void D3D11_INTERNAL_CycleActiveTexture(
 
     container->activeTexture = container->textures[container->textureCount - 1];
 
-    if (renderer->debug_mode && container->debugName != NULL) {
+    if (renderer->debugMode && container->debugName != NULL) {
         D3D11_INTERNAL_SetTextureName(
             renderer,
             container->activeTexture,
@@ -2373,7 +2373,7 @@ static D3D11Buffer *D3D11_INTERNAL_CreateBuffer(
 
 static SDL_GPUBuffer *D3D11_CreateBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     Uint32 size)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
@@ -2382,17 +2382,17 @@ static SDL_GPUBuffer *D3D11_CreateBuffer(
     D3D11_BUFFER_DESC bufferDesc;
 
     bufferDesc.BindFlags = 0;
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         bufferDesc.BindFlags |= D3D11_BIND_VERTEX_BUFFER;
     }
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
         bufferDesc.BindFlags |= D3D11_BIND_INDEX_BUFFER;
     }
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         bufferDesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
     }
 
-    if (usage_flags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
+    if (usageFlags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
         bufferDesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE;
@@ -2404,10 +2404,10 @@ static SDL_GPUBuffer *D3D11_CreateBuffer(
     bufferDesc.StructureByteStride = 0;
     bufferDesc.MiscFlags = 0;
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         bufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS;
     }
-    if (usage_flags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
+    if (usageFlags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
         bufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
@@ -2496,7 +2496,7 @@ static void D3D11_INTERNAL_CycleActiveBuffer(
 
     container->activeBuffer = container->buffers[container->bufferCount - 1];
 
-    if (renderer->debug_mode && container->debugName != NULL) {
+    if (renderer->debugMode && container->debugName != NULL) {
         D3D11_INTERNAL_SetBufferName(
             renderer,
             container->activeBuffer,
@@ -2524,21 +2524,21 @@ static D3D11TransferBuffer *D3D11_INTERNAL_CreateTransferBuffer(
     D3D11Renderer *renderer,
     Uint32 size)
 {
-    D3D11TransferBuffer *transfer_buffer = SDL_malloc(sizeof(D3D11TransferBuffer));
+    D3D11TransferBuffer *transferBuffer = SDL_malloc(sizeof(D3D11TransferBuffer));
 
-    transfer_buffer->data = (Uint8 *)SDL_malloc(size);
-    transfer_buffer->size = size;
-    SDL_AtomicSet(&transfer_buffer->referenceCount, 0);
+    transferBuffer->data = (Uint8 *)SDL_malloc(size);
+    transferBuffer->size = size;
+    SDL_AtomicSet(&transferBuffer->referenceCount, 0);
 
-    transfer_buffer->bufferDownloads = NULL;
-    transfer_buffer->bufferDownloadCount = 0;
-    transfer_buffer->bufferDownloadCapacity = 0;
+    transferBuffer->bufferDownloads = NULL;
+    transferBuffer->bufferDownloadCount = 0;
+    transferBuffer->bufferDownloadCapacity = 0;
 
-    transfer_buffer->textureDownloads = NULL;
-    transfer_buffer->textureDownloadCount = 0;
-    transfer_buffer->textureDownloadCapacity = 0;
+    transferBuffer->textureDownloads = NULL;
+    transferBuffer->textureDownloadCount = 0;
+    transferBuffer->textureDownloadCapacity = 0;
 
-    return transfer_buffer;
+    return transferBuffer;
 }
 
 // This actually returns a container handle so we can rotate buffers on Cycle.
@@ -2596,11 +2596,11 @@ static void D3D11_INTERNAL_CycleActiveTransferBuffer(
 
 static void *D3D11_MapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer,
+    SDL_GPUTransferBuffer *transferBuffer,
     bool cycle)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
-    D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)transfer_buffer;
+    D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)transferBuffer;
     D3D11TransferBuffer *buffer = container->activeBuffer;
 
     // Rotate the transfer buffer if necessary
@@ -2618,28 +2618,28 @@ static void *D3D11_MapTransferBuffer(
 
 static void D3D11_UnmapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     // no-op
     (void)driverData;
-    (void)transfer_buffer;
+    (void)transferBuffer;
 }
 
 // Copy Pass
 
 static void D3D11_BeginCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     // no-op
 }
 
 static void D3D11_UploadToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11TransferBufferContainer *srcTransferContainer = (D3D11TransferBufferContainer *)source->transfer_buffer;
     D3D11TransferBuffer *srcTransferBuffer = srcTransferContainer->activeBuffer;
@@ -2724,12 +2724,12 @@ static void D3D11_UploadToTexture(
 }
 
 static void D3D11_UploadToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11TransferBufferContainer *transferContainer = (D3D11TransferBufferContainer *)source->transfer_buffer;
     D3D11TransferBuffer *d3d11TransferBuffer = transferContainer->activeBuffer;
@@ -2781,11 +2781,11 @@ static void D3D11_UploadToBuffer(
 }
 
 static void D3D11_DownloadFromTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = d3d11CommandBuffer->renderer;
     D3D11TransferBufferContainer *dstTransferContainer = (D3D11TransferBufferContainer *)destination->transfer_buffer;
     D3D11TransferBuffer *d3d11TransferBuffer = dstTransferContainer->activeBuffer;
@@ -2886,11 +2886,11 @@ static void D3D11_DownloadFromTexture(
 }
 
 static void D3D11_DownloadFromBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = d3d11CommandBuffer->renderer;
     D3D11TransferBufferContainer *dstTransferContainer = (D3D11TransferBufferContainer *)destination->transfer_buffer;
     D3D11TransferBuffer *d3d11TransferBuffer = dstTransferContainer->activeBuffer;
@@ -2944,7 +2944,7 @@ static void D3D11_DownloadFromBuffer(
 }
 
 static void D3D11_CopyTextureToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -2952,7 +2952,7 @@ static void D3D11_CopyTextureToTexture(
     Uint32 d,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11TextureContainer *srcContainer = (D3D11TextureContainer *)source->texture;
     D3D11TextureContainer *dstContainer = (D3D11TextureContainer *)destination->texture;
@@ -2987,13 +2987,13 @@ static void D3D11_CopyTextureToTexture(
 }
 
 static void D3D11_CopyBufferToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11BufferContainer *srcBufferContainer = (D3D11BufferContainer *)source->buffer;
     D3D11BufferContainer *dstBufferContainer = (D3D11BufferContainer *)destination->buffer;
@@ -3021,10 +3021,10 @@ static void D3D11_CopyBufferToBuffer(
 }
 
 static void D3D11_GenerateMipmaps(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUTexture *texture)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11TextureContainer *d3d11TextureContainer = (D3D11TextureContainer *)texture;
 
     ID3D11DeviceContext1_GenerateMips(
@@ -3037,7 +3037,7 @@ static void D3D11_GenerateMipmaps(
 }
 
 static void D3D11_EndCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     // no-op
 }
@@ -3048,7 +3048,7 @@ static void D3D11_INTERNAL_AllocateCommandBuffers(
     D3D11Renderer *renderer,
     Uint32 allocateCount)
 {
-    D3D11CommandBuffer *command_buffer;
+    D3D11CommandBuffer *commandBuffer;
     HRESULT res;
 
     renderer->availableCommandBufferCapacity += allocateCount;
@@ -3058,50 +3058,50 @@ static void D3D11_INTERNAL_AllocateCommandBuffers(
         sizeof(D3D11CommandBuffer *) * renderer->availableCommandBufferCapacity);
 
     for (Uint32 i = 0; i < allocateCount; i += 1) {
-        command_buffer = SDL_calloc(1, sizeof(D3D11CommandBuffer));
-        command_buffer->renderer = renderer;
+        commandBuffer = SDL_calloc(1, sizeof(D3D11CommandBuffer));
+        commandBuffer->renderer = renderer;
 
         // Deferred Device Context
         res = ID3D11Device1_CreateDeferredContext1(
             renderer->device,
             0,
-            &command_buffer->context);
+            &commandBuffer->context);
         ERROR_CHECK("Could not create deferred context");
 
         // Initialize debug annotation support, if available
         ID3D11DeviceContext_QueryInterface(
-            command_buffer->context,
+            commandBuffer->context,
             &D3D_IID_ID3DUserDefinedAnnotation,
-            (void **)&command_buffer->annotation);
+            (void **)&commandBuffer->annotation);
 
         // Window handling
-        command_buffer->windowDataCapacity = 1;
-        command_buffer->windowDataCount = 0;
-        command_buffer->windowDatas = SDL_malloc(
-            command_buffer->windowDataCapacity * sizeof(D3D11WindowData *));
+        commandBuffer->windowDataCapacity = 1;
+        commandBuffer->windowDataCount = 0;
+        commandBuffer->windowDatas = SDL_malloc(
+            commandBuffer->windowDataCapacity * sizeof(D3D11WindowData *));
 
         // Reference Counting
-        command_buffer->usedBufferCapacity = 4;
-        command_buffer->usedBufferCount = 0;
-        command_buffer->usedBuffers = SDL_malloc(
-            command_buffer->usedBufferCapacity * sizeof(D3D11Buffer *));
+        commandBuffer->usedBufferCapacity = 4;
+        commandBuffer->usedBufferCount = 0;
+        commandBuffer->usedBuffers = SDL_malloc(
+            commandBuffer->usedBufferCapacity * sizeof(D3D11Buffer *));
 
-        command_buffer->usedTransferBufferCapacity = 4;
-        command_buffer->usedTransferBufferCount = 0;
-        command_buffer->usedTransferBuffers = SDL_malloc(
-            command_buffer->usedTransferBufferCapacity * sizeof(D3D11TransferBuffer *));
+        commandBuffer->usedTransferBufferCapacity = 4;
+        commandBuffer->usedTransferBufferCount = 0;
+        commandBuffer->usedTransferBuffers = SDL_malloc(
+            commandBuffer->usedTransferBufferCapacity * sizeof(D3D11TransferBuffer *));
 
-        command_buffer->usedTextureCapacity = 4;
-        command_buffer->usedTextureCount = 0;
-        command_buffer->usedTextures = SDL_malloc(
-            command_buffer->usedTextureCapacity * sizeof(D3D11Texture *));
+        commandBuffer->usedTextureCapacity = 4;
+        commandBuffer->usedTextureCount = 0;
+        commandBuffer->usedTextures = SDL_malloc(
+            commandBuffer->usedTextureCapacity * sizeof(D3D11Texture *));
 
-        command_buffer->usedUniformBufferCapacity = 4;
-        command_buffer->usedUniformBufferCount = 0;
-        command_buffer->usedUniformBuffers = SDL_malloc(
-            command_buffer->usedUniformBufferCapacity * sizeof(D3D11UniformBuffer *));
+        commandBuffer->usedUniformBufferCapacity = 4;
+        commandBuffer->usedUniformBufferCount = 0;
+        commandBuffer->usedUniformBuffers = SDL_malloc(
+            commandBuffer->usedUniformBufferCapacity * sizeof(D3D11UniformBuffer *));
 
-        renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
+        renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
         renderer->availableCommandBufferCount += 1;
     }
 }
@@ -3109,7 +3109,7 @@ static void D3D11_INTERNAL_AllocateCommandBuffers(
 static D3D11CommandBuffer *D3D11_INTERNAL_GetInactiveCommandBufferFromPool(
     D3D11Renderer *renderer)
 {
-    D3D11CommandBuffer *command_buffer;
+    D3D11CommandBuffer *commandBuffer;
 
     if (renderer->availableCommandBufferCount == 0) {
         D3D11_INTERNAL_AllocateCommandBuffers(
@@ -3117,10 +3117,10 @@ static D3D11CommandBuffer *D3D11_INTERNAL_GetInactiveCommandBufferFromPool(
             renderer->availableCommandBufferCapacity);
     }
 
-    command_buffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
+    commandBuffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
     renderer->availableCommandBufferCount -= 1;
 
-    return command_buffer;
+    return commandBuffer;
 }
 
 static bool D3D11_INTERNAL_CreateFence(
@@ -3158,9 +3158,9 @@ static bool D3D11_INTERNAL_CreateFence(
 }
 
 static bool D3D11_INTERNAL_AcquireFence(
-    D3D11CommandBuffer *command_buffer)
+    D3D11CommandBuffer *commandBuffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11Fence *fence;
 
@@ -3181,8 +3181,8 @@ static bool D3D11_INTERNAL_AcquireFence(
     SDL_UnlockMutex(renderer->fenceLock);
 
     // Associate the fence with the command buffer
-    command_buffer->fence = fence;
-    (void)SDL_AtomicIncRef(&command_buffer->fence->referenceCount);
+    commandBuffer->fence = fence;
+    (void)SDL_AtomicIncRef(&commandBuffer->fence->referenceCount);
 
     return true;
 }
@@ -3191,58 +3191,58 @@ static SDL_GPUCommandBuffer *D3D11_AcquireCommandBuffer(
     SDL_GPURenderer *driverData)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
-    D3D11CommandBuffer *command_buffer;
+    D3D11CommandBuffer *commandBuffer;
     Uint32 i;
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-    command_buffer = D3D11_INTERNAL_GetInactiveCommandBufferFromPool(renderer);
-    command_buffer->graphics_pipeline = NULL;
-    command_buffer->stencilRef = 0;
-    command_buffer->blend_constants = (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f };
-    command_buffer->compute_pipeline = NULL;
+    commandBuffer = D3D11_INTERNAL_GetInactiveCommandBufferFromPool(renderer);
+    commandBuffer->graphicsPipeline = NULL;
+    commandBuffer->stencilRef = 0;
+    commandBuffer->blendConstants = (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f };
+    commandBuffer->computePipeline = NULL;
     for (i = 0; i < MAX_COLOR_TARGET_BINDINGS; i += 1) {
-        command_buffer->colorTargetResolveTexture[i] = NULL;
-        command_buffer->colorTargetResolveSubresourceIndex[i] = 0;
-        command_buffer->colorTargetMsaaHandle[i] = NULL;
-        command_buffer->colorTargetMsaaFormat[i] = DXGI_FORMAT_UNKNOWN;
+        commandBuffer->colorTargetResolveTexture[i] = NULL;
+        commandBuffer->colorTargetResolveSubresourceIndex[i] = 0;
+        commandBuffer->colorTargetMsaaHandle[i] = NULL;
+        commandBuffer->colorTargetMsaaFormat[i] = DXGI_FORMAT_UNKNOWN;
     }
 
     for (i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        command_buffer->vertexUniformBuffers[i] = NULL;
-        command_buffer->fragmentUniformBuffers[i] = NULL;
-        command_buffer->computeUniformBuffers[i] = NULL;
+        commandBuffer->vertexUniformBuffers[i] = NULL;
+        commandBuffer->fragmentUniformBuffers[i] = NULL;
+        commandBuffer->computeUniformBuffers[i] = NULL;
     }
 
-    command_buffer->needVertexSamplerBind = true;
-    command_buffer->needVertexResourceBind = true;
-    command_buffer->needVertexUniformBufferBind = true;
-    command_buffer->needFragmentSamplerBind = true;
-    command_buffer->needFragmentResourceBind = true;
-    command_buffer->needFragmentUniformBufferBind = true;
-    command_buffer->needComputeUAVBind = true;
-    command_buffer->needComputeSRVBind = true;
-    command_buffer->needComputeUniformBufferBind = true;
+    commandBuffer->needVertexSamplerBind = true;
+    commandBuffer->needVertexResourceBind = true;
+    commandBuffer->needVertexUniformBufferBind = true;
+    commandBuffer->needFragmentSamplerBind = true;
+    commandBuffer->needFragmentResourceBind = true;
+    commandBuffer->needFragmentUniformBufferBind = true;
+    commandBuffer->needComputeUAVBind = true;
+    commandBuffer->needComputeSRVBind = true;
+    commandBuffer->needComputeUniformBufferBind = true;
 
-    SDL_zeroa(command_buffer->vertexSamplers);
-    SDL_zeroa(command_buffer->vertexShaderResourceViews);
-    SDL_zeroa(command_buffer->fragmentSamplers);
-    SDL_zeroa(command_buffer->fragmentShaderResourceViews);
-    SDL_zeroa(command_buffer->computeShaderResourceViews);
-    SDL_zeroa(command_buffer->computeUnorderedAccessViews);
+    SDL_zeroa(commandBuffer->vertexSamplers);
+    SDL_zeroa(commandBuffer->vertexShaderResourceViews);
+    SDL_zeroa(commandBuffer->fragmentSamplers);
+    SDL_zeroa(commandBuffer->fragmentShaderResourceViews);
+    SDL_zeroa(commandBuffer->computeShaderResourceViews);
+    SDL_zeroa(commandBuffer->computeUnorderedAccessViews);
 
-    D3D11_INTERNAL_AcquireFence(command_buffer);
-    command_buffer->autoReleaseFence = 1;
+    D3D11_INTERNAL_AcquireFence(commandBuffer);
+    commandBuffer->autoReleaseFence = 1;
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
-    return (SDL_GPUCommandBuffer *)command_buffer;
+    return (SDL_GPUCommandBuffer *)commandBuffer;
 }
 
 static D3D11UniformBuffer *D3D11_INTERNAL_AcquireUniformBufferFromPool(
-    D3D11CommandBuffer *command_buffer)
+    D3D11CommandBuffer *commandBuffer)
 {
-    D3D11Renderer *renderer = command_buffer->renderer;
+    D3D11Renderer *renderer = commandBuffer->renderer;
     D3D11UniformBuffer *uniformBuffer;
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
@@ -3258,7 +3258,7 @@ static D3D11UniformBuffer *D3D11_INTERNAL_AcquireUniformBufferFromPool(
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
-    D3D11_INTERNAL_TrackUniformBuffer(command_buffer, uniformBuffer);
+    D3D11_INTERNAL_TrackUniformBuffer(commandBuffer, uniformBuffer);
 
     return uniformBuffer;
 }
@@ -3285,7 +3285,7 @@ static void D3D11_INTERNAL_ReturnUniformBufferToPool(
 static void D3D11_INTERNAL_PushUniformData(
     D3D11CommandBuffer *d3d11CommandBuffer,
     SDL_GPUShaderStage shaderStage,
-    Uint32 slot_index,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
@@ -3295,23 +3295,23 @@ static void D3D11_INTERNAL_PushUniformData(
     HRESULT res;
 
     if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-        if (d3d11CommandBuffer->vertexUniformBuffers[slot_index] == NULL) {
-            d3d11CommandBuffer->vertexUniformBuffers[slot_index] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
+        if (d3d11CommandBuffer->vertexUniformBuffers[slotIndex] == NULL) {
+            d3d11CommandBuffer->vertexUniformBuffers[slotIndex] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
                 d3d11CommandBuffer);
         }
-        d3d11UniformBuffer = d3d11CommandBuffer->vertexUniformBuffers[slot_index];
+        d3d11UniformBuffer = d3d11CommandBuffer->vertexUniformBuffers[slotIndex];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-        if (d3d11CommandBuffer->fragmentUniformBuffers[slot_index] == NULL) {
-            d3d11CommandBuffer->fragmentUniformBuffers[slot_index] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
+        if (d3d11CommandBuffer->fragmentUniformBuffers[slotIndex] == NULL) {
+            d3d11CommandBuffer->fragmentUniformBuffers[slotIndex] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
                 d3d11CommandBuffer);
         }
-        d3d11UniformBuffer = d3d11CommandBuffer->fragmentUniformBuffers[slot_index];
+        d3d11UniformBuffer = d3d11CommandBuffer->fragmentUniformBuffers[slotIndex];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-        if (d3d11CommandBuffer->computeUniformBuffers[slot_index] == NULL) {
-            d3d11CommandBuffer->computeUniformBuffers[slot_index] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
+        if (d3d11CommandBuffer->computeUniformBuffers[slotIndex] == NULL) {
+            d3d11CommandBuffer->computeUniformBuffers[slotIndex] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
                 d3d11CommandBuffer);
         }
-        d3d11UniformBuffer = d3d11CommandBuffer->computeUniformBuffers[slot_index];
+        d3d11UniformBuffer = d3d11CommandBuffer->computeUniformBuffers[slotIndex];
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -3336,11 +3336,11 @@ static void D3D11_INTERNAL_PushUniformData(
         d3d11UniformBuffer->writeOffset = 0;
 
         if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-            d3d11CommandBuffer->vertexUniformBuffers[slot_index] = d3d11UniformBuffer;
+            d3d11CommandBuffer->vertexUniformBuffers[slotIndex] = d3d11UniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-            d3d11CommandBuffer->fragmentUniformBuffers[slot_index] = d3d11UniformBuffer;
+            d3d11CommandBuffer->fragmentUniformBuffers[slotIndex] = d3d11UniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-            d3d11CommandBuffer->computeUniformBuffers[slot_index] = d3d11UniformBuffer;
+            d3d11CommandBuffer->computeUniformBuffers[slotIndex] = d3d11UniformBuffer;
         } else {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         }
@@ -3381,10 +3381,10 @@ static void D3D11_INTERNAL_PushUniformData(
 }
 
 static void D3D11_SetViewport(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUViewport *viewport)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11_VIEWPORT vp = {
         viewport->x,
         viewport->y,
@@ -3401,10 +3401,10 @@ static void D3D11_SetViewport(
 }
 
 static void D3D11_SetScissor(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_Rect *scissor)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11_RECT rect = {
         scissor->x,
         scissor->y,
@@ -3419,46 +3419,46 @@ static void D3D11_SetScissor(
 }
 
 static void D3D11_SetBlendConstants(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_FColor blend_constants)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_FColor blendConstants)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
-    FLOAT blendFactor[4] = { blend_constants.r, blend_constants.g, blend_constants.b, blend_constants.a };
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    FLOAT blendFactor[4] = { blendConstants.r, blendConstants.g, blendConstants.b, blendConstants.a };
 
-    d3d11CommandBuffer->blend_constants = blend_constants;
+    d3d11CommandBuffer->blendConstants = blendConstants;
 
-    if (d3d11CommandBuffer->graphics_pipeline != NULL) {
+    if (d3d11CommandBuffer->graphicsPipeline != NULL) {
         ID3D11DeviceContext_OMSetBlendState(
             d3d11CommandBuffer->context,
-            d3d11CommandBuffer->graphics_pipeline->colorAttachmentBlendState,
+            d3d11CommandBuffer->graphicsPipeline->colorAttachmentBlendState,
             blendFactor,
-            d3d11CommandBuffer->graphics_pipeline->multisample_state.sample_mask);
+            d3d11CommandBuffer->graphicsPipeline->multisampleState.sample_mask);
     }
 }
 
 static void D3D11_SetStencilReference(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     Uint8 reference)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
 
     d3d11CommandBuffer->stencilRef = reference;
 
-    if (d3d11CommandBuffer->graphics_pipeline != NULL) {
+    if (d3d11CommandBuffer->graphicsPipeline != NULL) {
         ID3D11DeviceContext_OMSetDepthStencilState(
             d3d11CommandBuffer->context,
-            d3d11CommandBuffer->graphics_pipeline->depth_stencil_state,
+            d3d11CommandBuffer->graphicsPipeline->depthStencilState,
             reference);
     }
 }
 
 static void D3D11_BeginRenderPass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
+    Uint32 numColorAttachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     ID3D11RenderTargetView *rtvs[MAX_COLOR_TARGET_BINDINGS];
     ID3D11DepthStencilView *dsv = NULL;
@@ -3481,14 +3481,14 @@ static void D3D11_BeginRenderPass(
     }
 
     // Set up the new color target bindings
-    for (Uint32 i = 0; i < num_color_attachments; i += 1) {
-        D3D11TextureContainer *container = (D3D11TextureContainer *)color_attachment_infos[i].texture;
+    for (Uint32 i = 0; i < numColorAttachments; i += 1) {
+        D3D11TextureContainer *container = (D3D11TextureContainer *)colorAttachmentInfos[i].texture;
         D3D11TextureSubresource *subresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level,
-            color_attachment_infos[i].cycle);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layer_or_depth_plane,
+            colorAttachmentInfos[i].mip_level,
+            colorAttachmentInfos[i].cycle);
 
         if (subresource->msaaHandle != NULL) {
             d3d11CommandBuffer->colorTargetResolveTexture[i] = subresource->parent;
@@ -3498,21 +3498,21 @@ static void D3D11_BeginRenderPass(
 
             rtvs[i] = subresource->msaaTargetView;
         } else {
-            Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
+            Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layer_or_depth_plane : 0;
             rtvs[i] = subresource->colorTargetViews[rtvIndex];
         }
 
-        if (color_attachment_infos[i].load_op == SDL_GPU_LOADOP_CLEAR) {
-            float clear_color[] = {
-                color_attachment_infos[i].clear_color.r,
-                color_attachment_infos[i].clear_color.g,
-                color_attachment_infos[i].clear_color.b,
-                color_attachment_infos[i].clear_color.a
+        if (colorAttachmentInfos[i].load_op == SDL_GPU_LOADOP_CLEAR) {
+            float clearColor[] = {
+                colorAttachmentInfos[i].clear_color.r,
+                colorAttachmentInfos[i].clear_color.g,
+                colorAttachmentInfos[i].clear_color.b,
+                colorAttachmentInfos[i].clear_color.a
             };
             ID3D11DeviceContext_ClearRenderTargetView(
                 d3d11CommandBuffer->context,
                 rtvs[i],
-                clear_color);
+                clearColor);
         }
 
         D3D11_INTERNAL_TrackTexture(
@@ -3521,14 +3521,14 @@ static void D3D11_BeginRenderPass(
     }
 
     // Get the DSV for the depth stencil attachment, if applicable
-    if (depth_stencil_attachment_info != NULL) {
-        D3D11TextureContainer *container = (D3D11TextureContainer *)depth_stencil_attachment_info->texture;
+    if (depthStencilAttachmentInfo != NULL) {
+        D3D11TextureContainer *container = (D3D11TextureContainer *)depthStencilAttachmentInfo->texture;
         D3D11TextureSubresource *subresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             container,
             0,
             0,
-            depth_stencil_attachment_info->cycle);
+            depthStencilAttachmentInfo->cycle);
 
         dsv = subresource->depthStencilTargetView;
 
@@ -3540,16 +3540,16 @@ static void D3D11_BeginRenderPass(
     // Actually set the RTs
     ID3D11DeviceContext_OMSetRenderTargets(
         d3d11CommandBuffer->context,
-        num_color_attachments,
-        num_color_attachments > 0 ? rtvs : NULL,
+        numColorAttachments,
+        numColorAttachments > 0 ? rtvs : NULL,
         dsv);
 
-    if (depth_stencil_attachment_info != NULL) {
+    if (depthStencilAttachmentInfo != NULL) {
         D3D11_CLEAR_FLAG dsClearFlags = 0;
-        if (depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_CLEAR) {
+        if (depthStencilAttachmentInfo->load_op == SDL_GPU_LOADOP_CLEAR) {
             dsClearFlags |= D3D11_CLEAR_DEPTH;
         }
-        if (depth_stencil_attachment_info->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
+        if (depthStencilAttachmentInfo->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
             dsClearFlags |= D3D11_CLEAR_STENCIL;
         }
 
@@ -3558,16 +3558,16 @@ static void D3D11_BeginRenderPass(
                 d3d11CommandBuffer->context,
                 dsv,
                 dsClearFlags,
-                depth_stencil_attachment_info->clear_value.depth,
-                depth_stencil_attachment_info->clear_value.stencil);
+                depthStencilAttachmentInfo->clear_value.depth,
+                depthStencilAttachmentInfo->clear_value.stencil);
         }
     }
 
     // The viewport cannot be larger than the smallest attachment.
-    for (Uint32 i = 0; i < num_color_attachments; i += 1) {
-        D3D11TextureContainer *container = (D3D11TextureContainer *)color_attachment_infos[i].texture;
-        Uint32 w = container->header.info.width >> color_attachment_infos[i].mip_level;
-        Uint32 h = container->header.info.height >> color_attachment_infos[i].mip_level;
+    for (Uint32 i = 0; i < numColorAttachments; i += 1) {
+        D3D11TextureContainer *container = (D3D11TextureContainer *)colorAttachmentInfos[i].texture;
+        Uint32 w = container->header.info.width >> colorAttachmentInfos[i].mip_level;
+        Uint32 h = container->header.info.height >> colorAttachmentInfos[i].mip_level;
 
         if (w < vpWidth) {
             vpWidth = w;
@@ -3578,8 +3578,8 @@ static void D3D11_BeginRenderPass(
         }
     }
 
-    if (depth_stencil_attachment_info != NULL) {
-        D3D11TextureContainer *container = (D3D11TextureContainer *)depth_stencil_attachment_info->texture;
+    if (depthStencilAttachmentInfo != NULL) {
+        D3D11TextureContainer *container = (D3D11TextureContainer *)depthStencilAttachmentInfo->texture;
         Uint32 w = container->header.info.width;
         Uint32 h = container->header.info.height;
 
@@ -3601,7 +3601,7 @@ static void D3D11_BeginRenderPass(
     viewport.maxDepth = 1;
 
     D3D11_SetViewport(
-        command_buffer,
+        commandBuffer,
         &viewport);
 
     scissorRect.x = 0;
@@ -3610,47 +3610,47 @@ static void D3D11_BeginRenderPass(
     scissorRect.h = (int)vpHeight;
 
     D3D11_SetScissor(
-        command_buffer,
+        commandBuffer,
         &scissorRect);
 
     D3D11_SetStencilReference(
-        command_buffer,
+        commandBuffer,
         0);
 
     D3D11_SetBlendConstants(
-        command_buffer,
+        commandBuffer,
         (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
 }
 
 static void D3D11_BindGraphicsPipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
-    D3D11GraphicsPipeline *pipeline = (D3D11GraphicsPipeline *)graphics_pipeline;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11GraphicsPipeline *pipeline = (D3D11GraphicsPipeline *)graphicsPipeline;
     FLOAT blendFactor[4] = {
-        d3d11CommandBuffer->blend_constants.r,
-        d3d11CommandBuffer->blend_constants.g,
-        d3d11CommandBuffer->blend_constants.b,
-        d3d11CommandBuffer->blend_constants.a
+        d3d11CommandBuffer->blendConstants.r,
+        d3d11CommandBuffer->blendConstants.g,
+        d3d11CommandBuffer->blendConstants.b,
+        d3d11CommandBuffer->blendConstants.a
     };
 
-    d3d11CommandBuffer->graphics_pipeline = pipeline;
+    d3d11CommandBuffer->graphicsPipeline = pipeline;
 
     ID3D11DeviceContext_OMSetBlendState(
         d3d11CommandBuffer->context,
         pipeline->colorAttachmentBlendState,
         blendFactor,
-        pipeline->multisample_state.sample_mask);
+        pipeline->multisampleState.sample_mask);
 
     ID3D11DeviceContext_OMSetDepthStencilState(
         d3d11CommandBuffer->context,
-        pipeline->depth_stencil_state,
+        pipeline->depthStencilState,
         d3d11CommandBuffer->stencilRef);
 
     ID3D11DeviceContext_IASetPrimitiveTopology(
         d3d11CommandBuffer->context,
-        SDLToD3D11_PrimitiveType[pipeline->primitive_type]);
+        SDLToD3D11_PrimitiveType[pipeline->primitiveType]);
 
     ID3D11DeviceContext_IASetInputLayout(
         d3d11CommandBuffer->context,
@@ -3658,17 +3658,17 @@ static void D3D11_BindGraphicsPipeline(
 
     ID3D11DeviceContext_RSSetState(
         d3d11CommandBuffer->context,
-        pipeline->rasterizer_state);
+        pipeline->rasterizerState);
 
     ID3D11DeviceContext_VSSetShader(
         d3d11CommandBuffer->context,
-        pipeline->vertex_shader,
+        pipeline->vertexShader,
         NULL,
         0);
 
     ID3D11DeviceContext_PSSetShader(
         d3d11CommandBuffer->context,
-        pipeline->fragment_shader,
+        pipeline->fragmentShader,
         NULL,
         0);
 
@@ -3693,32 +3693,32 @@ static void D3D11_BindGraphicsPipeline(
 }
 
 static void D3D11_BindVertexBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_binding,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstBinding,
     const SDL_GPUBufferBinding *bindings,
-    Uint32 num_bindings)
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
+    for (Uint32 i = 0; i < numBindings; i += 1) {
         D3D11Buffer *currentBuffer = ((D3D11BufferContainer *)bindings[i].buffer)->activeBuffer;
-        d3d11CommandBuffer->vertexBuffers[first_binding + i] = currentBuffer->handle;
-        d3d11CommandBuffer->vertexBufferOffsets[first_binding + i] = bindings[i].offset;
+        d3d11CommandBuffer->vertexBuffers[firstBinding + i] = currentBuffer->handle;
+        d3d11CommandBuffer->vertexBufferOffsets[firstBinding + i] = bindings[i].offset;
         D3D11_INTERNAL_TrackBuffer(d3d11CommandBuffer, currentBuffer);
     }
 
     d3d11CommandBuffer->vertexBufferCount =
-        SDL_max(d3d11CommandBuffer->vertexBufferCount, first_binding + num_bindings);
+        SDL_max(d3d11CommandBuffer->vertexBufferCount, firstBinding + numBindings);
 
     d3d11CommandBuffer->needVertexBufferBind = true;
 }
 
 static void D3D11_BindIndexBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize index_element_size)
+    SDL_GPUIndexElementSize indexElementSize)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Buffer *d3d11Buffer = ((D3D11BufferContainer *)pBinding->buffer)->activeBuffer;
 
     D3D11_INTERNAL_TrackBuffer(d3d11CommandBuffer, d3d11Buffer);
@@ -3726,29 +3726,29 @@ static void D3D11_BindIndexBuffer(
     ID3D11DeviceContext_IASetIndexBuffer(
         d3d11CommandBuffer->context,
         d3d11Buffer->handle,
-        SDLToD3D11_IndexType[index_element_size],
+        SDLToD3D11_IndexType[indexElementSize],
         (UINT)pBinding->offset);
 }
 
 static void D3D11_BindVertexSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)texture_sampler_bindings[i].texture;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)textureSamplerBindings[i].texture;
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->vertexSamplers[first_slot + i] =
-            ((D3D11Sampler *)texture_sampler_bindings[i].sampler)->handle;
+        d3d11CommandBuffer->vertexSamplers[firstSlot + i] =
+            ((D3D11Sampler *)textureSamplerBindings[i].sampler)->handle;
 
-        d3d11CommandBuffer->vertexShaderResourceViews[first_slot + i] =
+        d3d11CommandBuffer->vertexShaderResourceViews[firstSlot + i] =
             textureContainer->activeTexture->shaderView;
     }
 
@@ -3757,71 +3757,71 @@ static void D3D11_BindVertexSamplers(
 }
 
 static void D3D11_BindVertexStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storageTextures[i];
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->vertexShaderResourceViews[first_slot + i +
-                                                      d3d11CommandBuffer->graphics_pipeline->vertexSamplerCount] = textureContainer->activeTexture->shaderView;
+        d3d11CommandBuffer->vertexShaderResourceViews[firstSlot + i +
+                                                      d3d11CommandBuffer->graphicsPipeline->vertexSamplerCount] = textureContainer->activeTexture->shaderView;
     }
 
     d3d11CommandBuffer->needVertexResourceBind = true;
 }
 
 static void D3D11_BindVertexStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11BufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (D3D11BufferContainer *)storage_buffers[i];
+    for (i = 0; i < numBindings; i += 1) {
+        bufferContainer = (D3D11BufferContainer *)storageBuffers[i];
 
         D3D11_INTERNAL_TrackBuffer(
             d3d11CommandBuffer,
             bufferContainer->activeBuffer);
 
-        d3d11CommandBuffer->vertexShaderResourceViews[first_slot + i +
-                                                      d3d11CommandBuffer->graphics_pipeline->vertexSamplerCount +
-                                                      d3d11CommandBuffer->graphics_pipeline->vertexStorageTextureCount] = bufferContainer->activeBuffer->srv;
+        d3d11CommandBuffer->vertexShaderResourceViews[firstSlot + i +
+                                                      d3d11CommandBuffer->graphicsPipeline->vertexSamplerCount +
+                                                      d3d11CommandBuffer->graphicsPipeline->vertexStorageTextureCount] = bufferContainer->activeBuffer->srv;
     }
 
     d3d11CommandBuffer->needVertexResourceBind = true;
 }
 
 static void D3D11_BindFragmentSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)texture_sampler_bindings[i].texture;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)textureSamplerBindings[i].texture;
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->fragmentSamplers[first_slot + i] =
-            ((D3D11Sampler *)texture_sampler_bindings[i].sampler)->handle;
+        d3d11CommandBuffer->fragmentSamplers[firstSlot + i] =
+            ((D3D11Sampler *)textureSamplerBindings[i].sampler)->handle;
 
-        d3d11CommandBuffer->fragmentShaderResourceViews[first_slot + i] =
+        d3d11CommandBuffer->fragmentShaderResourceViews[firstSlot + i] =
             textureContainer->activeTexture->shaderView;
     }
 
@@ -3830,227 +3830,227 @@ static void D3D11_BindFragmentSamplers(
 }
 
 static void D3D11_BindFragmentStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storageTextures[i];
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->fragmentShaderResourceViews[first_slot + i +
-                                                        d3d11CommandBuffer->graphics_pipeline->fragmentSamplerCount] = textureContainer->activeTexture->shaderView;
+        d3d11CommandBuffer->fragmentShaderResourceViews[firstSlot + i +
+                                                        d3d11CommandBuffer->graphicsPipeline->fragmentSamplerCount] = textureContainer->activeTexture->shaderView;
     }
 
     d3d11CommandBuffer->needFragmentResourceBind = true;
 }
 
 static void D3D11_BindFragmentStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11BufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (D3D11BufferContainer *)storage_buffers[i];
+    for (i = 0; i < numBindings; i += 1) {
+        bufferContainer = (D3D11BufferContainer *)storageBuffers[i];
 
         D3D11_INTERNAL_TrackBuffer(
             d3d11CommandBuffer,
             bufferContainer->activeBuffer);
 
-        d3d11CommandBuffer->fragmentShaderResourceViews[first_slot + i +
-                                                        d3d11CommandBuffer->graphics_pipeline->fragmentSamplerCount +
-                                                        d3d11CommandBuffer->graphics_pipeline->fragmentStorageTextureCount] = bufferContainer->activeBuffer->srv;
+        d3d11CommandBuffer->fragmentShaderResourceViews[firstSlot + i +
+                                                        d3d11CommandBuffer->graphicsPipeline->fragmentSamplerCount +
+                                                        d3d11CommandBuffer->graphicsPipeline->fragmentStorageTextureCount] = bufferContainer->activeBuffer->srv;
     }
 
     d3d11CommandBuffer->needFragmentResourceBind = true;
 }
 
 static void D3D11_INTERNAL_BindGraphicsResources(
-    D3D11CommandBuffer *command_buffer)
+    D3D11CommandBuffer *commandBuffer)
 {
-    D3D11GraphicsPipeline *graphics_pipeline = command_buffer->graphics_pipeline;
+    D3D11GraphicsPipeline *graphicsPipeline = commandBuffer->graphicsPipeline;
 
     Uint32 vertexResourceCount =
-        graphics_pipeline->vertexSamplerCount +
-        graphics_pipeline->vertexStorageTextureCount +
-        graphics_pipeline->vertexStorageBufferCount;
+        graphicsPipeline->vertexSamplerCount +
+        graphicsPipeline->vertexStorageTextureCount +
+        graphicsPipeline->vertexStorageBufferCount;
 
     Uint32 fragmentResourceCount =
-        graphics_pipeline->fragmentSamplerCount +
-        graphics_pipeline->fragmentStorageTextureCount +
-        graphics_pipeline->fragmentStorageBufferCount;
+        graphicsPipeline->fragmentSamplerCount +
+        graphicsPipeline->fragmentStorageTextureCount +
+        graphicsPipeline->fragmentStorageBufferCount;
 
     ID3D11Buffer *nullBuf = NULL;
     Uint32 offsetInConstants, blockSizeInConstants, i;
 
-    if (command_buffer->needVertexBufferBind) {
+    if (commandBuffer->needVertexBufferBind) {
         ID3D11DeviceContext_IASetVertexBuffers(
-            command_buffer->context,
+            commandBuffer->context,
             0,
-            command_buffer->vertexBufferCount,
-            command_buffer->vertexBuffers,
-            graphics_pipeline->vertexStrides,
-            command_buffer->vertexBufferOffsets);
+            commandBuffer->vertexBufferCount,
+            commandBuffer->vertexBuffers,
+            graphicsPipeline->vertexStrides,
+            commandBuffer->vertexBufferOffsets);
     }
 
-    if (command_buffer->needVertexSamplerBind) {
-        if (graphics_pipeline->vertexSamplerCount > 0) {
+    if (commandBuffer->needVertexSamplerBind) {
+        if (graphicsPipeline->vertexSamplerCount > 0) {
             ID3D11DeviceContext_VSSetSamplers(
-                command_buffer->context,
+                commandBuffer->context,
                 0,
-                graphics_pipeline->vertexSamplerCount,
-                command_buffer->vertexSamplers);
+                graphicsPipeline->vertexSamplerCount,
+                commandBuffer->vertexSamplers);
         }
 
-        command_buffer->needVertexSamplerBind = false;
+        commandBuffer->needVertexSamplerBind = false;
     }
 
-    if (command_buffer->needVertexResourceBind) {
+    if (commandBuffer->needVertexResourceBind) {
         if (vertexResourceCount > 0) {
             ID3D11DeviceContext_VSSetShaderResources(
-                command_buffer->context,
+                commandBuffer->context,
                 0,
                 vertexResourceCount,
-                command_buffer->vertexShaderResourceViews);
+                commandBuffer->vertexShaderResourceViews);
         }
 
-        command_buffer->needVertexResourceBind = false;
+        commandBuffer->needVertexResourceBind = false;
     }
 
-    if (command_buffer->needVertexUniformBufferBind) {
-        for (i = 0; i < graphics_pipeline->vertexUniformBufferCount; i += 1) {
+    if (commandBuffer->needVertexUniformBufferBind) {
+        for (i = 0; i < graphicsPipeline->vertexUniformBufferCount; i += 1) {
             /* stupid workaround for god awful D3D11 drivers
              * see: https://learn.microsoft.com/en-us/windows/win32/api/d3d11_1/nf-d3d11_1-id3d11devicecontext1-vssetconstantbuffers1#calling-vssetconstantbuffers1-with-command-list-emulation
              */
             ID3D11DeviceContext1_VSSetConstantBuffers(
-                command_buffer->context,
+                commandBuffer->context,
                 i,
                 1,
                 &nullBuf);
 
-            offsetInConstants = command_buffer->vertexUniformBuffers[i]->drawOffset / 16;
-            blockSizeInConstants = command_buffer->vertexUniformBuffers[i]->currentBlockSize / 16;
+            offsetInConstants = commandBuffer->vertexUniformBuffers[i]->drawOffset / 16;
+            blockSizeInConstants = commandBuffer->vertexUniformBuffers[i]->currentBlockSize / 16;
 
             ID3D11DeviceContext1_VSSetConstantBuffers1(
-                command_buffer->context,
+                commandBuffer->context,
                 i,
                 1,
-                &command_buffer->vertexUniformBuffers[i]->buffer,
+                &commandBuffer->vertexUniformBuffers[i]->buffer,
                 &offsetInConstants,
                 &blockSizeInConstants);
         }
 
-        command_buffer->needVertexUniformBufferBind = false;
+        commandBuffer->needVertexUniformBufferBind = false;
     }
 
-    if (command_buffer->needFragmentSamplerBind) {
-        if (graphics_pipeline->fragmentSamplerCount > 0) {
+    if (commandBuffer->needFragmentSamplerBind) {
+        if (graphicsPipeline->fragmentSamplerCount > 0) {
             ID3D11DeviceContext_PSSetSamplers(
-                command_buffer->context,
+                commandBuffer->context,
                 0,
-                graphics_pipeline->fragmentSamplerCount,
-                command_buffer->fragmentSamplers);
+                graphicsPipeline->fragmentSamplerCount,
+                commandBuffer->fragmentSamplers);
         }
 
-        command_buffer->needFragmentSamplerBind = false;
+        commandBuffer->needFragmentSamplerBind = false;
     }
 
-    if (command_buffer->needFragmentResourceBind) {
+    if (commandBuffer->needFragmentResourceBind) {
         if (fragmentResourceCount > 0) {
             ID3D11DeviceContext_PSSetShaderResources(
-                command_buffer->context,
+                commandBuffer->context,
                 0,
                 fragmentResourceCount,
-                command_buffer->fragmentShaderResourceViews);
+                commandBuffer->fragmentShaderResourceViews);
         }
 
-        command_buffer->needFragmentResourceBind = false;
+        commandBuffer->needFragmentResourceBind = false;
     }
 
-    if (command_buffer->needFragmentUniformBufferBind) {
-        for (i = 0; i < graphics_pipeline->fragmentUniformBufferCount; i += 1) {
+    if (commandBuffer->needFragmentUniformBufferBind) {
+        for (i = 0; i < graphicsPipeline->fragmentUniformBufferCount; i += 1) {
             /* stupid workaround for god awful D3D11 drivers
              * see: https://learn.microsoft.com/en-us/windows/win32/api/d3d11_1/nf-d3d11_1-id3d11devicecontext1-pssetconstantbuffers1#calling-pssetconstantbuffers1-with-command-list-emulation
              */
             ID3D11DeviceContext1_PSSetConstantBuffers(
-                command_buffer->context,
+                commandBuffer->context,
                 i,
                 1,
                 &nullBuf);
 
-            offsetInConstants = command_buffer->fragmentUniformBuffers[i]->drawOffset / 16;
-            blockSizeInConstants = command_buffer->fragmentUniformBuffers[i]->currentBlockSize / 16;
+            offsetInConstants = commandBuffer->fragmentUniformBuffers[i]->drawOffset / 16;
+            blockSizeInConstants = commandBuffer->fragmentUniformBuffers[i]->currentBlockSize / 16;
 
             ID3D11DeviceContext1_PSSetConstantBuffers1(
-                command_buffer->context,
+                commandBuffer->context,
                 i,
                 1,
-                &command_buffer->fragmentUniformBuffers[i]->buffer,
+                &commandBuffer->fragmentUniformBuffers[i]->buffer,
                 &offsetInConstants,
                 &blockSizeInConstants);
         }
 
-        command_buffer->needFragmentUniformBufferBind = false;
+        commandBuffer->needFragmentUniformBufferBind = false;
     }
 }
 
 static void D3D11_DrawIndexedPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_indices,
-    Uint32 num_instances,
-    Uint32 first_index,
-    Sint32 vertex_offset,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numIndices,
+    Uint32 numInstances,
+    Uint32 firstIndex,
+    Sint32 vertexOffset,
+    Uint32 firstInstance)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11_INTERNAL_BindGraphicsResources(d3d11CommandBuffer);
 
     ID3D11DeviceContext_DrawIndexedInstanced(
         d3d11CommandBuffer->context,
-        num_indices,
-        num_instances,
-        first_index,
-        vertex_offset,
-        first_instance);
+        numIndices,
+        numInstances,
+        firstIndex,
+        vertexOffset,
+        firstInstance);
 }
 
 static void D3D11_DrawPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_vertices,
-    Uint32 num_instances,
-    Uint32 first_vertex,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numVertices,
+    Uint32 numInstances,
+    Uint32 firstVertex,
+    Uint32 firstInstance)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11_INTERNAL_BindGraphicsResources(d3d11CommandBuffer);
 
     ID3D11DeviceContext_DrawInstanced(
         d3d11CommandBuffer->context,
-        num_vertices,
-        num_instances,
-        first_vertex,
-        first_instance);
+        numVertices,
+        numInstances,
+        firstVertex,
+        firstInstance);
 }
 
 static void D3D11_DrawPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11_INTERNAL_BindGraphicsResources(d3d11CommandBuffer);
 
     D3D11Buffer *d3d11Buffer = ((D3D11BufferContainer *)buffer)->activeBuffer;
@@ -4058,7 +4058,7 @@ static void D3D11_DrawPrimitivesIndirect(
     /* D3D11: "We have multi-draw at home!"
      * Multi-draw at home:
      */
-    for (Uint32 i = 0; i < draw_count; i += 1) {
+    for (Uint32 i = 0; i < drawCount; i += 1) {
         ID3D11DeviceContext_DrawInstancedIndirect(
             d3d11CommandBuffer->context,
             d3d11Buffer->handle,
@@ -4069,13 +4069,13 @@ static void D3D11_DrawPrimitivesIndirect(
 }
 
 static void D3D11_DrawIndexedPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11_INTERNAL_BindGraphicsResources(d3d11CommandBuffer);
 
     D3D11Buffer *d3d11Buffer = ((D3D11BufferContainer *)buffer)->activeBuffer;
@@ -4083,7 +4083,7 @@ static void D3D11_DrawIndexedPrimitivesIndirect(
     /* D3D11: "We have multi-draw at home!"
      * Multi-draw at home:
      */
-    for (Uint32 i = 0; i < draw_count; i += 1) {
+    for (Uint32 i = 0; i < drawCount; i += 1) {
         ID3D11DeviceContext_DrawIndexedInstancedIndirect(
             d3d11CommandBuffer->context,
             d3d11Buffer->handle,
@@ -4094,9 +4094,9 @@ static void D3D11_DrawIndexedPrimitivesIndirect(
 }
 
 static void D3D11_EndRenderPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     Uint32 i;
 
     // Set render target slots to NULL to avoid NULL set behavior
@@ -4133,29 +4133,29 @@ static void D3D11_EndRenderPass(
 }
 
 static void D3D11_PushVertexUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     D3D11_INTERNAL_PushUniformData(
-        (D3D11CommandBuffer *)command_buffer,
+        (D3D11CommandBuffer *)commandBuffer,
         SDL_GPU_SHADERSTAGE_VERTEX,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void D3D11_PushFragmentUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     D3D11_INTERNAL_PushUniformData(
-        (D3D11CommandBuffer *)command_buffer,
+        (D3D11CommandBuffer *)commandBuffer,
         SDL_GPU_SHADERSTAGE_FRAGMENT,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
@@ -4163,22 +4163,22 @@ static void D3D11_PushFragmentUniformData(
 // Blit
 
 static void D3D11_Blit(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flip_mode,
+    SDL_FlipMode flipMode,
     SDL_GPUFilter filter,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     BlitPipelineCacheEntry *blitPipelines = &renderer->blitPipelines[0];
 
     SDL_GPU_BlitCommon(
-        command_buffer,
+        commandBuffer,
         source,
         destination,
-        flip_mode,
+        flipMode,
         filter,
         cycle,
         renderer->blitLinearSampler,
@@ -4196,21 +4196,21 @@ static void D3D11_Blit(
 // Compute State
 
 static void D3D11_BeginComputePass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
-    Uint32 num_storage_texture_bindings,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
-    Uint32 num_storage_buffer_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
+    Uint32 numStorageTextureBindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
+    Uint32 numStorageBufferBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11TextureContainer *textureContainer;
     D3D11TextureSubresource *textureSubresource;
     D3D11BufferContainer *bufferContainer;
     D3D11Buffer *buffer;
     Uint32 i;
 
-    for (i = 0; i < num_storage_texture_bindings; i += 1) {
-        textureContainer = (D3D11TextureContainer *)storage_texture_bindings[i].texture;
+    for (i = 0; i < numStorageTextureBindings; i += 1) {
+        textureContainer = (D3D11TextureContainer *)storageTextureBindings[i].texture;
         if (!(textureContainer->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
         }
@@ -4218,9 +4218,9 @@ static void D3D11_BeginComputePass(
         textureSubresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             d3d11CommandBuffer->renderer,
             textureContainer,
-            storage_texture_bindings[i].layer,
-            storage_texture_bindings[i].mip_level,
-            storage_texture_bindings[i].cycle);
+            storageTextureBindings[i].layer,
+            storageTextureBindings[i].mip_level,
+            storageTextureBindings[i].cycle);
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
@@ -4229,32 +4229,32 @@ static void D3D11_BeginComputePass(
         d3d11CommandBuffer->computeUnorderedAccessViews[i] = textureSubresource->uav;
     }
 
-    for (i = 0; i < num_storage_buffer_bindings; i += 1) {
-        bufferContainer = (D3D11BufferContainer *)storage_buffer_bindings[i].buffer;
+    for (i = 0; i < numStorageBufferBindings; i += 1) {
+        bufferContainer = (D3D11BufferContainer *)storageBufferBindings[i].buffer;
 
         buffer = D3D11_INTERNAL_PrepareBufferForWrite(
             d3d11CommandBuffer->renderer,
             bufferContainer,
-            storage_buffer_bindings[i].cycle);
+            storageBufferBindings[i].cycle);
 
         D3D11_INTERNAL_TrackBuffer(
             d3d11CommandBuffer,
             buffer);
 
-        d3d11CommandBuffer->computeUnorderedAccessViews[i + num_storage_texture_bindings] = buffer->uav;
+        d3d11CommandBuffer->computeUnorderedAccessViews[i + numStorageTextureBindings] = buffer->uav;
     }
 
     d3d11CommandBuffer->needComputeUAVBind = true;
 }
 
 static void D3D11_BindComputePipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUComputePipeline *computePipeline)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
-    D3D11ComputePipeline *pipeline = (D3D11ComputePipeline *)compute_pipeline;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11ComputePipeline *pipeline = (D3D11ComputePipeline *)computePipeline;
 
-    d3d11CommandBuffer->compute_pipeline = pipeline;
+    d3d11CommandBuffer->computePipeline = pipeline;
 
     ID3D11DeviceContext_CSSetShader(
         d3d11CommandBuffer->context,
@@ -4263,7 +4263,7 @@ static void D3D11_BindComputePipeline(
         0);
 
     // Acquire uniform buffers if necessary
-    for (Uint32 i = 0; i < pipeline->num_uniform_buffers; i += 1) {
+    for (Uint32 i = 0; i < pipeline->numUniformBuffers; i += 1) {
         if (d3d11CommandBuffer->computeUniformBuffers[i] == NULL) {
             d3d11CommandBuffer->computeUniformBuffers[i] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
                 d3d11CommandBuffer);
@@ -4274,21 +4274,21 @@ static void D3D11_BindComputePipeline(
 }
 
 static void D3D11_BindComputeStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storageTextures[i];
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->computeShaderResourceViews[first_slot + i] =
+        d3d11CommandBuffer->computeShaderResourceViews[firstSlot + i] =
             textureContainer->activeTexture->shaderView;
     }
 
@@ -4296,128 +4296,128 @@ static void D3D11_BindComputeStorageTextures(
 }
 
 static void D3D11_BindComputeStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11BufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (D3D11BufferContainer *)storage_buffers[i];
+    for (i = 0; i < numBindings; i += 1) {
+        bufferContainer = (D3D11BufferContainer *)storageBuffers[i];
 
         D3D11_INTERNAL_TrackBuffer(
             d3d11CommandBuffer,
             bufferContainer->activeBuffer);
 
-        d3d11CommandBuffer->computeShaderResourceViews[first_slot + i +
-                                                       d3d11CommandBuffer->compute_pipeline->num_readonly_storage_textures] = bufferContainer->activeBuffer->srv;
+        d3d11CommandBuffer->computeShaderResourceViews[firstSlot + i +
+                                                       d3d11CommandBuffer->computePipeline->numReadonlyStorageTextures] = bufferContainer->activeBuffer->srv;
     }
 
     d3d11CommandBuffer->needComputeSRVBind = true;
 }
 
 static void D3D11_PushComputeUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     D3D11_INTERNAL_PushUniformData(
-        (D3D11CommandBuffer *)command_buffer,
+        (D3D11CommandBuffer *)commandBuffer,
         SDL_GPU_SHADERSTAGE_COMPUTE,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void D3D11_INTERNAL_BindComputeResources(
-    D3D11CommandBuffer *command_buffer)
+    D3D11CommandBuffer *commandBuffer)
 {
-    D3D11ComputePipeline *compute_pipeline = command_buffer->compute_pipeline;
+    D3D11ComputePipeline *computePipeline = commandBuffer->computePipeline;
 
     Uint32 readOnlyResourceCount =
-        compute_pipeline->num_readonly_storage_textures +
-        compute_pipeline->num_readonly_storage_buffers;
+        computePipeline->numReadonlyStorageTextures +
+        computePipeline->numReadonlyStorageBuffers;
 
     Uint32 writeOnlyResourceCount =
-        compute_pipeline->num_writeonly_storage_textures +
-        compute_pipeline->num_writeonly_storage_buffers;
+        computePipeline->numWriteonlyStorageTextures +
+        computePipeline->numWriteonlyStorageBuffers;
 
     ID3D11Buffer *nullBuf = NULL;
     Uint32 offsetInConstants, blockSizeInConstants, i;
 
-    if (command_buffer->needComputeUAVBind) {
+    if (commandBuffer->needComputeUAVBind) {
         ID3D11DeviceContext_CSSetUnorderedAccessViews(
-            command_buffer->context,
+            commandBuffer->context,
             0,
             writeOnlyResourceCount,
-            command_buffer->computeUnorderedAccessViews,
+            commandBuffer->computeUnorderedAccessViews,
             NULL);
 
-        command_buffer->needComputeUAVBind = false;
+        commandBuffer->needComputeUAVBind = false;
     }
 
-    if (command_buffer->needComputeSRVBind) {
+    if (commandBuffer->needComputeSRVBind) {
         ID3D11DeviceContext_CSSetShaderResources(
-            command_buffer->context,
+            commandBuffer->context,
             0,
             readOnlyResourceCount,
-            command_buffer->computeShaderResourceViews);
+            commandBuffer->computeShaderResourceViews);
 
-        command_buffer->needComputeSRVBind = false;
+        commandBuffer->needComputeSRVBind = false;
     }
 
-    if (command_buffer->needComputeUniformBufferBind) {
-        for (i = 0; i < compute_pipeline->num_uniform_buffers; i += 1) {
+    if (commandBuffer->needComputeUniformBufferBind) {
+        for (i = 0; i < computePipeline->numUniformBuffers; i += 1) {
             /* stupid workaround for god awful D3D11 drivers
              * see: https://learn.microsoft.com/en-us/windows/win32/api/d3d11_1/nf-d3d11_1-id3d11devicecontext1-vssetconstantbuffers1#calling-vssetconstantbuffers1-with-command-list-emulation
              */
             ID3D11DeviceContext1_CSSetConstantBuffers(
-                command_buffer->context,
+                commandBuffer->context,
                 i,
                 1,
                 &nullBuf);
 
-            offsetInConstants = command_buffer->computeUniformBuffers[i]->drawOffset / 16;
-            blockSizeInConstants = command_buffer->computeUniformBuffers[i]->currentBlockSize / 16;
+            offsetInConstants = commandBuffer->computeUniformBuffers[i]->drawOffset / 16;
+            blockSizeInConstants = commandBuffer->computeUniformBuffers[i]->currentBlockSize / 16;
 
             ID3D11DeviceContext1_CSSetConstantBuffers1(
-                command_buffer->context,
+                commandBuffer->context,
                 i,
                 1,
-                &command_buffer->computeUniformBuffers[i]->buffer,
+                &commandBuffer->computeUniformBuffers[i]->buffer,
                 &offsetInConstants,
                 &blockSizeInConstants);
         }
-        command_buffer->needComputeUniformBufferBind = false;
+        commandBuffer->needComputeUniformBufferBind = false;
     }
 }
 
 static void D3D11_DispatchCompute(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 groupcount_x,
-    Uint32 groupcount_y,
-    Uint32 groupcount_z)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 groupcountX,
+    Uint32 groupcountY,
+    Uint32 groupcountZ)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11_INTERNAL_BindComputeResources(d3d11CommandBuffer);
 
     ID3D11DeviceContext_Dispatch(
         d3d11CommandBuffer->context,
-        groupcount_x,
-        groupcount_y,
-        groupcount_z);
+        groupcountX,
+        groupcountY,
+        groupcountZ);
 }
 
 static void D3D11_DispatchComputeIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Buffer *d3d11Buffer = ((D3D11BufferContainer *)buffer)->activeBuffer;
 
     D3D11_INTERNAL_BindComputeResources(d3d11CommandBuffer);
@@ -4431,9 +4431,9 @@ static void D3D11_DispatchComputeIndirect(
 }
 
 static void D3D11_EndComputePass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
 
     // reset UAV slots to avoid NULL set behavior
     // https://learn.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-cssetshaderresources
@@ -4444,7 +4444,7 @@ static void D3D11_EndComputePass(
         nullUAVs,
         NULL);
 
-    d3d11CommandBuffer->compute_pipeline = NULL;
+    d3d11CommandBuffer->computePipeline = NULL;
 
     // Reset bind state
     SDL_zeroa(d3d11CommandBuffer->computeUnorderedAccessViews);
@@ -4495,7 +4495,7 @@ static void D3D11_ReleaseFence(
 
 static void D3D11_INTERNAL_MapAndCopyBufferDownload(
     D3D11Renderer *renderer,
-    D3D11TransferBuffer *transfer_buffer,
+    D3D11TransferBuffer *transferBuffer,
     D3D11BufferDownload *bufferDownload)
 {
     D3D11_MAPPED_SUBRESOURCE subres;
@@ -4512,7 +4512,7 @@ static void D3D11_INTERNAL_MapAndCopyBufferDownload(
     ERROR_CHECK_RETURN("Failed to map staging buffer", )
 
     SDL_memcpy(
-        ((Uint8 *)transfer_buffer->data) + bufferDownload->dstOffset,
+        ((Uint8 *)transferBuffer->data) + bufferDownload->dstOffset,
         ((Uint8 *)subres.pData),
         bufferDownload->size);
 
@@ -4527,7 +4527,7 @@ static void D3D11_INTERNAL_MapAndCopyBufferDownload(
 
 static void D3D11_INTERNAL_MapAndCopyTextureDownload(
     D3D11Renderer *renderer,
-    D3D11TransferBuffer *transfer_buffer,
+    D3D11TransferBuffer *transferBuffer,
     D3D11TextureDownload *textureDownload)
 {
     D3D11_MAPPED_SUBRESOURCE subres;
@@ -4550,7 +4550,7 @@ static void D3D11_INTERNAL_MapAndCopyTextureDownload(
 
         for (row = 0; row < textureDownload->height; row += 1) {
             SDL_memcpy(
-                transfer_buffer->data + dataPtrOffset,
+                transferBuffer->data + dataPtrOffset,
                 (Uint8 *)subres.pData + (depth * subres.DepthPitch) + (row * subres.RowPitch),
                 textureDownload->bytesPerRow);
             dataPtrOffset += textureDownload->bytesPerRow;
@@ -4569,71 +4569,71 @@ static void D3D11_INTERNAL_MapAndCopyTextureDownload(
 
 static void D3D11_INTERNAL_CleanCommandBuffer(
     D3D11Renderer *renderer,
-    D3D11CommandBuffer *command_buffer)
+    D3D11CommandBuffer *commandBuffer)
 {
     Uint32 i, j;
 
     // Perform deferred download map and copy
 
-    for (i = 0; i < command_buffer->usedTransferBufferCount; i += 1) {
-        D3D11TransferBuffer *transfer_buffer = command_buffer->usedTransferBuffers[i];
+    for (i = 0; i < commandBuffer->usedTransferBufferCount; i += 1) {
+        D3D11TransferBuffer *transferBuffer = commandBuffer->usedTransferBuffers[i];
 
-        for (j = 0; j < transfer_buffer->bufferDownloadCount; j += 1) {
+        for (j = 0; j < transferBuffer->bufferDownloadCount; j += 1) {
             D3D11_INTERNAL_MapAndCopyBufferDownload(
                 renderer,
-                transfer_buffer,
-                &transfer_buffer->bufferDownloads[j]);
+                transferBuffer,
+                &transferBuffer->bufferDownloads[j]);
         }
 
-        for (j = 0; j < transfer_buffer->textureDownloadCount; j += 1) {
+        for (j = 0; j < transferBuffer->textureDownloadCount; j += 1) {
             D3D11_INTERNAL_MapAndCopyTextureDownload(
                 renderer,
-                transfer_buffer,
-                &transfer_buffer->textureDownloads[j]);
+                transferBuffer,
+                &transferBuffer->textureDownloads[j]);
         }
 
-        transfer_buffer->bufferDownloadCount = 0;
-        transfer_buffer->textureDownloadCount = 0;
+        transferBuffer->bufferDownloadCount = 0;
+        transferBuffer->textureDownloadCount = 0;
     }
 
     // Uniform buffers are now available
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
 
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
         D3D11_INTERNAL_ReturnUniformBufferToPool(
             renderer,
-            command_buffer->usedUniformBuffers[i]);
+            commandBuffer->usedUniformBuffers[i]);
     }
-    command_buffer->usedUniformBufferCount = 0;
+    commandBuffer->usedUniformBufferCount = 0;
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
     // Reference Counting
 
-    for (i = 0; i < command_buffer->usedBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedBuffers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedBuffers[i]->referenceCount);
     }
-    command_buffer->usedBufferCount = 0;
+    commandBuffer->usedBufferCount = 0;
 
-    for (i = 0; i < command_buffer->usedTransferBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedTransferBuffers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedTransferBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedTransferBuffers[i]->referenceCount);
     }
-    command_buffer->usedTransferBufferCount = 0;
+    commandBuffer->usedTransferBufferCount = 0;
 
-    for (i = 0; i < command_buffer->usedTextureCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedTextures[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedTextureCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedTextures[i]->referenceCount);
     }
-    command_buffer->usedTextureCount = 0;
+    commandBuffer->usedTextureCount = 0;
 
     // Reset presentation
-    command_buffer->windowDataCount = 0;
+    commandBuffer->windowDataCount = 0;
 
     // The fence is now available (unless SubmitAndAcquireFence was called)
-    if (command_buffer->autoReleaseFence) {
+    if (commandBuffer->autoReleaseFence) {
         D3D11_ReleaseFence(
             (SDL_GPURenderer *)renderer,
-            (SDL_GPUFence *)command_buffer->fence);
+            (SDL_GPUFence *)commandBuffer->fence);
     }
 
     // Return command buffer to pool
@@ -4644,13 +4644,13 @@ static void D3D11_INTERNAL_CleanCommandBuffer(
             renderer->availableCommandBuffers,
             renderer->availableCommandBufferCapacity * sizeof(D3D11CommandBuffer *));
     }
-    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
+    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
     renderer->availableCommandBufferCount += 1;
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
     // Remove this command buffer from the submitted list
     for (i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-        if (renderer->submittedCommandBuffers[i] == command_buffer) {
+        if (renderer->submittedCommandBuffers[i] == commandBuffer) {
             renderer->submittedCommandBuffers[i] = renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount - 1];
             renderer->submittedCommandBufferCount -= 1;
         }
@@ -4735,17 +4735,17 @@ static void D3D11_INTERNAL_WaitForFence(
 
 static void D3D11_WaitForFences(
     SDL_GPURenderer *driverData,
-    bool wait_all,
+    bool waitAll,
     SDL_GPUFence *const *fences,
-    Uint32 num_fences)
+    Uint32 numFences)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11Fence *fence;
     BOOL queryData;
     HRESULT res = S_FALSE;
 
-    if (wait_all) {
-        for (Uint32 i = 0; i < num_fences; i += 1) {
+    if (waitAll) {
+        for (Uint32 i = 0; i < numFences; i += 1) {
             fence = (D3D11Fence *)fences[i];
             D3D11_INTERNAL_WaitForFence(renderer, fence);
         }
@@ -4753,7 +4753,7 @@ static void D3D11_WaitForFences(
         SDL_LockMutex(renderer->contextLock);
 
         while (res != S_OK) {
-            for (Uint32 i = 0; i < num_fences; i += 1) {
+            for (Uint32 i = 0; i < numFences; i += 1) {
                 fence = (D3D11Fence *)fences[i];
                 res = ID3D11DeviceContext_GetData(
                     renderer->immediateContext,
@@ -4892,8 +4892,8 @@ static bool D3D11_INTERNAL_InitializeSwapchainTexture(
 static bool D3D11_INTERNAL_CreateSwapchain(
     D3D11Renderer *renderer,
     D3D11WindowData *windowData,
-    SDL_GPUSwapchainComposition swapchain_composition,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUSwapchainComposition swapchainComposition,
+    SDL_GPUPresentMode presentMode)
 {
     HWND dxgiHandle;
     int width, height;
@@ -4915,7 +4915,7 @@ static bool D3D11_INTERNAL_CreateSwapchain(
     // Get the window size
     SDL_GetWindowSize(windowData->window, &width, &height);
 
-    swapchainFormat = SwapchainCompositionToTextureFormat[swapchain_composition];
+    swapchainFormat = SwapchainCompositionToTextureFormat[swapchainComposition];
 
     // Initialize the swapchain buffer descriptor
     swapchainDesc.BufferDesc.Width = 0;
@@ -4984,7 +4984,7 @@ static bool D3D11_INTERNAL_CreateSwapchain(
         IDXGIFactory1_Release(pParent);
     }
 
-    if (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
+    if (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
         // Set the color space, support already verified if we hit this block
         IDXGISwapChain3_QueryInterface(
             swapchain,
@@ -4993,17 +4993,17 @@ static bool D3D11_INTERNAL_CreateSwapchain(
 
         IDXGISwapChain3_SetColorSpace1(
             swapchain3,
-            SwapchainCompositionToColorSpace[swapchain_composition]);
+            SwapchainCompositionToColorSpace[swapchainComposition]);
 
         IDXGISwapChain3_Release(swapchain3);
     }
 
     // Initialize the swapchain data
     windowData->swapchain = swapchain;
-    windowData->present_mode = present_mode;
-    windowData->swapchain_composition = swapchain_composition;
+    windowData->presentMode = presentMode;
+    windowData->swapchainComposition = swapchainComposition;
     windowData->swapchainFormat = swapchainFormat;
-    windowData->swapchainColorSpace = SwapchainCompositionToColorSpace[swapchain_composition];
+    windowData->swapchainColorSpace = SwapchainCompositionToColorSpace[swapchainComposition];
     windowData->frameCounter = 0;
 
     for (i = 0; i < MAX_FRAMES_IN_FLIGHT; i += 1) {
@@ -5017,7 +5017,7 @@ static bool D3D11_INTERNAL_CreateSwapchain(
             renderer,
             swapchain,
             swapchainFormat,
-            (swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : windowData->swapchainFormat,
+            (swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : windowData->swapchainFormat,
             &windowData->texture)) {
         IDXGISwapChain_Release(swapchain);
         return false;
@@ -5033,7 +5033,7 @@ static bool D3D11_INTERNAL_CreateSwapchain(
     windowData->textureContainer.textureCapacity = 1;
 
     windowData->textureContainer.header.info.layer_count_or_depth = 1;
-    windowData->textureContainer.header.info.format = SwapchainCompositionToSDLTextureFormat[windowData->swapchain_composition];
+    windowData->textureContainer.header.info.format = SwapchainCompositionToSDLTextureFormat[windowData->swapchainComposition];
     windowData->textureContainer.header.info.type = SDL_GPU_TEXTURETYPE_2D;
     windowData->textureContainer.header.info.num_levels = 1;
     windowData->textureContainer.header.info.sample_count = SDL_GPU_SAMPLECOUNT_1;
@@ -5071,14 +5071,14 @@ static bool D3D11_INTERNAL_ResizeSwapchain(
         renderer,
         windowData->swapchain,
         windowData->swapchainFormat,
-        (windowData->swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : windowData->swapchainFormat,
+        (windowData->swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : windowData->swapchainFormat,
         &windowData->texture);
 }
 
 static bool D3D11_SupportsSwapchainComposition(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition)
+    SDL_GPUSwapchainComposition swapchainComposition)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     DXGI_FORMAT format;
@@ -5087,7 +5087,7 @@ static bool D3D11_SupportsSwapchainComposition(
     Uint32 colorSpaceSupport;
     HRESULT res;
 
-    format = SwapchainCompositionToTextureFormat[swapchain_composition];
+    format = SwapchainCompositionToTextureFormat[swapchainComposition];
 
     res = ID3D11Device_CheckFormatSupport(
         renderer->device,
@@ -5109,14 +5109,14 @@ static bool D3D11_SupportsSwapchainComposition(
     }
 
     // Check the color space support if necessary
-    if (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
+    if (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
         if (SUCCEEDED(IDXGISwapChain3_QueryInterface(
                 windowData->swapchain,
                 &D3D_IID_IDXGISwapChain3,
                 (void **)&swapchain3))) {
             IDXGISwapChain3_CheckColorSpaceSupport(
                 swapchain3,
-                SwapchainCompositionToColorSpace[swapchain_composition],
+                SwapchainCompositionToColorSpace[swapchainComposition],
                 &colorSpaceSupport);
 
             IDXGISwapChain3_Release(swapchain3);
@@ -5136,11 +5136,11 @@ static bool D3D11_SupportsSwapchainComposition(
 static bool D3D11_SupportsPresentMode(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUPresentMode presentMode)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     (void)window; // used by other backends
-    switch (present_mode) {
+    switch (presentMode) {
     case SDL_GPU_PRESENTMODE_IMMEDIATE:
     case SDL_GPU_PRESENTMODE_VSYNC:
         return true;
@@ -5252,12 +5252,12 @@ static void D3D11_ReleaseWindow(
 }
 
 static SDL_GPUTexture *D3D11_AcquireSwapchainTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_Window *window,
     Uint32 *w,
     Uint32 *h)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11WindowData *windowData;
     DXGI_SWAP_CHAIN_DESC swapchainDesc;
@@ -5284,7 +5284,7 @@ static SDL_GPUTexture *D3D11_AcquireSwapchainTexture(
     }
 
     if (windowData->inFlightFences[windowData->frameCounter] != NULL) {
-        if (windowData->present_mode == SDL_GPU_PRESENTMODE_VSYNC) {
+        if (windowData->presentMode == SDL_GPU_PRESENTMODE_VSYNC) {
             // In VSYNC mode, block until the least recent presented frame is done
             D3D11_WaitForFences(
                 (SDL_GPURenderer *)renderer,
@@ -5357,8 +5357,8 @@ static SDL_GPUTextureFormat D3D11_GetSwapchainTextureFormat(
 static bool D3D11_SetSwapchainParameters(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUSwapchainComposition swapchainComposition,
+    SDL_GPUPresentMode presentMode)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11WindowData *windowData = D3D11_INTERNAL_FetchWindowData(window);
@@ -5368,19 +5368,19 @@ static bool D3D11_SetSwapchainParameters(
         return false;
     }
 
-    if (!D3D11_SupportsSwapchainComposition(driverData, window, swapchain_composition)) {
+    if (!D3D11_SupportsSwapchainComposition(driverData, window, swapchainComposition)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Swapchain composition not supported!");
         return false;
     }
 
-    if (!D3D11_SupportsPresentMode(driverData, window, present_mode)) {
+    if (!D3D11_SupportsPresentMode(driverData, window, presentMode)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Present mode not supported!");
         return false;
     }
 
     if (
-        swapchain_composition != windowData->swapchain_composition ||
-        present_mode != windowData->present_mode) {
+        swapchainComposition != windowData->swapchainComposition ||
+        presentMode != windowData->presentMode) {
         D3D11_Wait(driverData);
 
         // Recreate the swapchain
@@ -5391,8 +5391,8 @@ static bool D3D11_SetSwapchainParameters(
         return D3D11_INTERNAL_CreateSwapchain(
             renderer,
             windowData,
-            swapchain_composition,
-            present_mode);
+            swapchainComposition,
+            presentMode);
     }
 
     return true;
@@ -5401,9 +5401,9 @@ static bool D3D11_SetSwapchainParameters(
 // Submission
 
 static void D3D11_Submit(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     ID3D11CommandList *commandList;
     HRESULT res;
@@ -5471,14 +5471,14 @@ static void D3D11_Submit(
         D3D11WindowData *windowData = d3d11CommandBuffer->windowDatas[i];
 
         Uint32 syncInterval = 1;
-        if (windowData->present_mode == SDL_GPU_PRESENTMODE_IMMEDIATE ||
-            (renderer->supportsFlipDiscard && windowData->present_mode == SDL_GPU_PRESENTMODE_MAILBOX)) {
+        if (windowData->presentMode == SDL_GPU_PRESENTMODE_IMMEDIATE ||
+            (renderer->supportsFlipDiscard && windowData->presentMode == SDL_GPU_PRESENTMODE_MAILBOX)) {
             syncInterval = 0;
         }
 
         Uint32 presentFlags = 0;
         if (renderer->supportsTearing &&
-            windowData->present_mode == SDL_GPU_PRESENTMODE_IMMEDIATE) {
+            windowData->presentMode == SDL_GPU_PRESENTMODE_IMMEDIATE) {
             presentFlags = DXGI_PRESENT_ALLOW_TEARING;
         }
 
@@ -5518,13 +5518,13 @@ static void D3D11_Submit(
 }
 
 static SDL_GPUFence *D3D11_SubmitAndAcquireFence(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
     D3D11Fence *fence = d3d11CommandBuffer->fence;
 
     d3d11CommandBuffer->autoReleaseFence = 0;
-    D3D11_Submit(command_buffer);
+    D3D11_Submit(commandBuffer);
 
     return (SDL_GPUFence *)fence;
 }
@@ -5533,7 +5533,7 @@ static void D3D11_Wait(
     SDL_GPURenderer *driverData)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
-    D3D11CommandBuffer *command_buffer;
+    D3D11CommandBuffer *commandBuffer;
 
     /*
      * Wait for all submitted command buffers to complete.
@@ -5548,8 +5548,8 @@ static void D3D11_Wait(
     SDL_LockMutex(renderer->contextLock); // This effectively acts as a lock around submittedCommandBuffers
 
     for (Sint32 i = renderer->submittedCommandBufferCount - 1; i >= 0; i -= 1) {
-        command_buffer = renderer->submittedCommandBuffers[i];
-        D3D11_INTERNAL_CleanCommandBuffer(renderer, command_buffer);
+        commandBuffer = renderer->submittedCommandBuffers[i];
+        D3D11_INTERNAL_CleanCommandBuffer(renderer, commandBuffer);
     }
 
     D3D11_INTERNAL_PerformPendingDestroys(renderer);
@@ -5630,34 +5630,34 @@ static bool D3D11_SupportsTextureFormat(
 
 // Device Creation
 
-static bool D3D11_PrepareDriver(SDL_VideoDevice *_this)
+static bool D3D11_PrepareDriver(SDL_VideoDevice *this)
 {
-    void *d3d11_dll, *dxgi_dll;
-    PFN_D3D11_CREATE_DEVICE D3D11CreateDeviceFunc;
+    void *d3d11Dll, *dxgiDll;
+    PFN_D3D11_CREATE_DEVICE d3D11CreateDeviceFunc;
     D3D_FEATURE_LEVEL levels[] = { D3D_FEATURE_LEVEL_11_1 };
-    PFN_CREATE_DXGI_FACTORY1 CreateDXGIFactoryFunc;
+    PFN_CREATE_DXGI_FACTORY1 createDxgiFactoryFunc;
     HRESULT res;
 
     // Can we load D3D11?
 
-    d3d11_dll = SDL_LoadObject(D3D11_DLL);
-    if (d3d11_dll == NULL) {
+    d3d11Dll = SDL_LoadObject(D3D11_DLL);
+    if (d3d11Dll == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find " D3D11_DLL);
         return false;
     }
 
-    D3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
-        d3d11_dll,
+    d3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
+        d3d11Dll,
         D3D11_CREATE_DEVICE_FUNC);
-    if (D3D11CreateDeviceFunc == NULL) {
+    if (d3D11CreateDeviceFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find function " D3D11_CREATE_DEVICE_FUNC " in " D3D11_DLL);
-        SDL_UnloadObject(d3d11_dll);
+        SDL_UnloadObject(d3d11Dll);
         return false;
     }
 
     // Can we create a device?
 
-    res = D3D11CreateDeviceFunc(
+    res = d3D11CreateDeviceFunc(
         NULL,
         D3D_DRIVER_TYPE_HARDWARE,
         NULL,
@@ -5669,7 +5669,7 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *_this)
         NULL,
         NULL);
 
-    SDL_UnloadObject(d3d11_dll);
+    SDL_UnloadObject(d3d11Dll);
 
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not create D3D11Device with feature level 11_1");
@@ -5678,17 +5678,17 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *_this)
 
     // Can we load DXGI?
 
-    dxgi_dll = SDL_LoadObject(DXGI_DLL);
-    if (dxgi_dll == NULL) {
+    dxgiDll = SDL_LoadObject(DXGI_DLL);
+    if (dxgiDll == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find " DXGI_DLL);
         return false;
     }
 
-    CreateDXGIFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
-        dxgi_dll,
+    createDxgiFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
+        dxgiDll,
         CREATE_DXGI_FACTORY1_FUNC);
-    SDL_UnloadObject(dxgi_dll); // We're not going to call this function, so we can just unload now.
-    if (CreateDXGIFactoryFunc == NULL) {
+    SDL_UnloadObject(dxgiDll); // We're not going to call this function, so we can just unload now.
+    if (createDxgiFactoryFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D11: Could not find function " CREATE_DXGI_FACTORY1_FUNC " in " DXGI_DLL);
         return false;
     }
@@ -5698,30 +5698,30 @@ static bool D3D11_PrepareDriver(SDL_VideoDevice *_this)
 
 static void D3D11_INTERNAL_TryInitializeDXGIDebug(D3D11Renderer *renderer)
 {
-    PFN_DXGI_GET_DEBUG_INTERFACE DXGIGetDebugInterfaceFunc;
+    PFN_DXGI_GET_DEBUG_INTERFACE dxgiGetDebugInterfaceFunc;
     HRESULT res;
 
-    renderer->dxgidebug_dll = SDL_LoadObject(DXGIDEBUG_DLL);
-    if (renderer->dxgidebug_dll == NULL) {
+    renderer->dxgidebugDll = SDL_LoadObject(DXGIDEBUG_DLL);
+    if (renderer->dxgidebugDll == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not find " DXGIDEBUG_DLL);
         return;
     }
 
-    DXGIGetDebugInterfaceFunc = (PFN_DXGI_GET_DEBUG_INTERFACE)SDL_LoadFunction(
-        renderer->dxgidebug_dll,
+    dxgiGetDebugInterfaceFunc = (PFN_DXGI_GET_DEBUG_INTERFACE)SDL_LoadFunction(
+        renderer->dxgidebugDll,
         DXGI_GET_DEBUG_INTERFACE_FUNC);
-    if (DXGIGetDebugInterfaceFunc == NULL) {
+    if (dxgiGetDebugInterfaceFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not load function: " DXGI_GET_DEBUG_INTERFACE_FUNC);
         return;
     }
 
-    res = DXGIGetDebugInterfaceFunc(&D3D_IID_IDXGIDebug, (void **)&renderer->dxgiDebug);
+    res = dxgiGetDebugInterfaceFunc(&D3D_IID_IDXGIDebug, (void **)&renderer->dxgiDebug);
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not get IDXGIDebug interface");
     }
 
 #ifdef HAVE_IDXGIINFOQUEUE
-    res = DXGIGetDebugInterfaceFunc(&D3D_IID_IDXGIInfoQueue, (void **)&renderer->dxgiInfoQueue);
+    res = dxgiGetDebugInterfaceFunc(&D3D_IID_IDXGIInfoQueue, (void **)&renderer->dxgiInfoQueue);
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not get IDXGIInfoQueue interface");
     }
@@ -5935,11 +5935,11 @@ static void D3D11_INTERNAL_DestroyBlitPipelines(
     }
 }
 
-static SDL_GPUDevice *D3D11_CreateDevice(bool debug_mode, bool preferLowPower, SDL_PropertiesID props)
+static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
 {
     D3D11Renderer *renderer;
-    PFN_CREATE_DXGI_FACTORY1 CreateDXGIFactoryFunc;
-    PFN_D3D11_CREATE_DEVICE D3D11CreateDeviceFunc;
+    PFN_CREATE_DXGI_FACTORY1 createDxgiFactoryFunc;
+    PFN_D3D11_CREATE_DEVICE d3D11CreateDeviceFunc;
     D3D_FEATURE_LEVEL levels[] = { D3D_FEATURE_LEVEL_11_1 };
     IDXGIFactory4 *factory4;
     IDXGIFactory5 *factory5;
@@ -5953,23 +5953,23 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debug_mode, bool preferLowPower, S
     renderer = (D3D11Renderer *)SDL_calloc(1, sizeof(D3D11Renderer));
 
     // Load the DXGI library
-    renderer->dxgi_dll = SDL_LoadObject(DXGI_DLL);
-    if (renderer->dxgi_dll == NULL) {
+    renderer->dxgiDll = SDL_LoadObject(DXGI_DLL);
+    if (renderer->dxgiDll == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not find " DXGI_DLL);
         return NULL;
     }
 
     // Load the CreateDXGIFactory1 function
-    CreateDXGIFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
-        renderer->dxgi_dll,
+    createDxgiFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
+        renderer->dxgiDll,
         CREATE_DXGI_FACTORY1_FUNC);
-    if (CreateDXGIFactoryFunc == NULL) {
+    if (createDxgiFactoryFunc == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not load function: " CREATE_DXGI_FACTORY1_FUNC);
         return NULL;
     }
 
     // Create the DXGI factory
-    res = CreateDXGIFactoryFunc(
+    res = createDxgiFactoryFunc(
         &D3D_IID_IDXGIFactory1,
         (void **)&renderer->factory);
     ERROR_CHECK_RETURN("Could not create DXGIFactory", NULL);
@@ -6025,36 +6025,36 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debug_mode, bool preferLowPower, S
     IDXGIAdapter1_GetDesc1(renderer->adapter, &adapterDesc);
 
     // Initialize the DXGI debug layer, if applicable
-    if (debug_mode) {
+    if (debugMode) {
         D3D11_INTERNAL_TryInitializeDXGIDebug(renderer);
     }
 
     // Load the D3D library
-    renderer->d3d11_dll = SDL_LoadObject(D3D11_DLL);
-    if (renderer->d3d11_dll == NULL) {
+    renderer->d3d11Dll = SDL_LoadObject(D3D11_DLL);
+    if (renderer->d3d11Dll == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not find " D3D11_DLL);
         return NULL;
     }
 
     // Load the CreateDevice function
-    D3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
-        renderer->d3d11_dll,
+    d3D11CreateDeviceFunc = (PFN_D3D11_CREATE_DEVICE)SDL_LoadFunction(
+        renderer->d3d11Dll,
         D3D11_CREATE_DEVICE_FUNC);
-    if (D3D11CreateDeviceFunc == NULL) {
+    if (d3D11CreateDeviceFunc == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not load function: " D3D11_CREATE_DEVICE_FUNC);
         return NULL;
     }
 
     // Set up device flags
     flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-    if (debug_mode) {
+    if (debugMode) {
         flags |= D3D11_CREATE_DEVICE_DEBUG;
     }
 
     // Create the device
     ID3D11Device *d3d11Device;
 tryCreateDevice:
-    res = D3D11CreateDeviceFunc(
+    res = d3D11CreateDeviceFunc(
         (IDXGIAdapter *)renderer->adapter,
         D3D_DRIVER_TYPE_UNKNOWN, // Must be UNKNOWN if adapter is non-null according to spec
         NULL,
@@ -6065,11 +6065,11 @@ tryCreateDevice:
         &d3d11Device,
         NULL,
         &renderer->immediateContext);
-    if (FAILED(res) && debug_mode) {
+    if (FAILED(res) && debugMode) {
         // If device creation failed, and we're in debug mode, remove the debug flag and try again.
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Creating device in debug mode failed with error " HRESULT_FMT ". Trying non-debug.", res);
         flags &= ~D3D11_CREATE_DEVICE_DEBUG;
-        debug_mode = 0;
+        debugMode = 0;
         goto tryCreateDevice;
     }
 
@@ -6118,7 +6118,7 @@ tryCreateDevice:
     renderer->windowLock = SDL_CreateMutex();
 
     // Initialize miscellaneous renderer members
-    renderer->debug_mode = (flags & D3D11_CREATE_DEVICE_DEBUG);
+    renderer->debugMode = (flags & D3D11_CREATE_DEVICE_DEBUG);
 
     // Create command buffer pool
     D3D11_INTERNAL_AllocateCommandBuffers(renderer, 2);

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -384,16 +384,16 @@ static D3D12_TEXTURE_ADDRESS_MODE SDLToD3D12_SamplerAddressMode[] = {
 };
 
 static D3D12_FILTER SDLToD3D12_Filter(
-    SDL_GPUFilter min_filter,
-    SDL_GPUFilter mag_filter,
-    SDL_GPUSamplerMipmapMode mipmap_mode,
+    SDL_GPUFilter minFilter,
+    SDL_GPUFilter magFilter,
+    SDL_GPUSamplerMipmapMode mipmapMode,
     bool comparisonEnabled,
     bool anisotropyEnabled)
 {
     D3D12_FILTER result = D3D12_ENCODE_BASIC_FILTER(
-        (min_filter == SDL_GPU_FILTER_LINEAR) ? 1 : 0,
-        (mag_filter == SDL_GPU_FILTER_LINEAR) ? 1 : 0,
-        (mipmap_mode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) ? 1 : 0,
+        (minFilter == SDL_GPU_FILTER_LINEAR) ? 1 : 0,
+        (magFilter == SDL_GPU_FILTER_LINEAR) ? 1 : 0,
+        (mipmapMode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) ? 1 : 0,
         comparisonEnabled ? 1 : 0);
 
     if (anisotropyEnabled) {
@@ -518,7 +518,7 @@ typedef struct D3D12WindowData
     IDXGISwapChain3 *swapchain;
 #endif
     SDL_GPUPresentMode present_mode;
-    SDL_GPUSwapchainComposition swapchain_composition;
+    SDL_GPUSwapchainComposition swapchainComposition;
     DXGI_COLOR_SPACE_TYPE swapchainColorSpace;
     Uint32 frameCounter;
 
@@ -743,9 +743,9 @@ struct D3D12Shader
     size_t bytecodeSize;
 
     Uint32 num_samplers;
-    Uint32 num_uniform_buffers;
-    Uint32 num_storage_buffers;
-    Uint32 num_storage_textures;
+    Uint32 numUniformBuffers;
+    Uint32 numStorageBuffers;
+    Uint32 numStorageTextures;
 };
 
 typedef struct D3D12GraphicsRootSignature
@@ -771,7 +771,7 @@ struct D3D12GraphicsPipeline
 {
     ID3D12PipelineState *pipelineState;
     D3D12GraphicsRootSignature *rootSignature;
-    SDL_GPUPrimitiveType primitive_type;
+    SDL_GPUPrimitiveType primitiveType;
 
     Uint32 vertexStrides[MAX_BUFFER_BINDINGS];
 
@@ -808,7 +808,7 @@ struct D3D12ComputePipeline
     Uint32 num_readonly_storage_buffers;
     Uint32 num_writeonly_storage_textures;
     Uint32 num_writeonly_storage_buffers;
-    Uint32 num_uniform_buffers;
+    Uint32 numUniformBuffers;
 
     SDL_AtomicInt referenceCount;
 };
@@ -870,7 +870,7 @@ struct D3D12UniformBuffer
 
 static void D3D12_ReleaseWindow(SDL_GPURenderer *driverData, SDL_Window *window);
 static void D3D12_Wait(SDL_GPURenderer *driverData);
-static void D3D12_WaitForFences(SDL_GPURenderer *driverData, bool wait_all, SDL_GPUFence *const *fences, Uint32 num_fences);
+static void D3D12_WaitForFences(SDL_GPURenderer *driverData, bool waitAll, SDL_GPUFence *const *fences, Uint32 numFences);
 static void D3D12_INTERNAL_ReleaseBlitPipelines(SDL_GPURenderer *driverData);
 
 // Helpers
@@ -1159,13 +1159,13 @@ static void D3D12_INTERNAL_DestroyGraphicsRootSignature(
 }
 
 static void D3D12_INTERNAL_DestroyGraphicsPipeline(
-    D3D12GraphicsPipeline *graphics_pipeline)
+    D3D12GraphicsPipeline *graphicsPipeline)
 {
-    if (graphics_pipeline->pipelineState) {
-        ID3D12PipelineState_Release(graphics_pipeline->pipelineState);
+    if (graphicsPipeline->pipelineState) {
+        ID3D12PipelineState_Release(graphicsPipeline->pipelineState);
     }
-    D3D12_INTERNAL_DestroyGraphicsRootSignature(graphics_pipeline->rootSignature);
-    SDL_free(graphics_pipeline);
+    D3D12_INTERNAL_DestroyGraphicsRootSignature(graphicsPipeline->rootSignature);
+    SDL_free(graphicsPipeline);
 }
 
 static void D3D12_INTERNAL_DestroyComputeRootSignature(
@@ -1181,13 +1181,13 @@ static void D3D12_INTERNAL_DestroyComputeRootSignature(
 }
 
 static void D3D12_INTERNAL_DestroyComputePipeline(
-    D3D12ComputePipeline *compute_pipeline)
+    D3D12ComputePipeline *computePipeline)
 {
-    if (compute_pipeline->pipelineState) {
-        ID3D12PipelineState_Release(compute_pipeline->pipelineState);
+    if (computePipeline->pipelineState) {
+        ID3D12PipelineState_Release(computePipeline->pipelineState);
     }
-    D3D12_INTERNAL_DestroyComputeRootSignature(compute_pipeline->rootSignature);
-    SDL_free(compute_pipeline);
+    D3D12_INTERNAL_DestroyComputeRootSignature(computePipeline->rootSignature);
+    SDL_free(computePipeline);
 }
 
 static void D3D12_INTERNAL_ReleaseFenceToPool(
@@ -1242,26 +1242,26 @@ static void D3D12_INTERNAL_DestroyDescriptorHeap(D3D12DescriptorHeap *descriptor
     SDL_free(descriptorHeap);
 }
 
-static void D3D12_INTERNAL_DestroyCommandBuffer(D3D12CommandBuffer *command_buffer)
+static void D3D12_INTERNAL_DestroyCommandBuffer(D3D12CommandBuffer *commandBuffer)
 {
-    if (!command_buffer) {
+    if (!commandBuffer) {
         return;
     }
-    if (command_buffer->graphicsCommandList) {
-        ID3D12GraphicsCommandList_Release(command_buffer->graphicsCommandList);
+    if (commandBuffer->graphicsCommandList) {
+        ID3D12GraphicsCommandList_Release(commandBuffer->graphicsCommandList);
     }
-    if (command_buffer->commandAllocator) {
-        ID3D12CommandAllocator_Release(command_buffer->commandAllocator);
+    if (commandBuffer->commandAllocator) {
+        ID3D12CommandAllocator_Release(commandBuffer->commandAllocator);
     }
-    SDL_free(command_buffer->presentDatas);
-    SDL_free(command_buffer->usedTextures);
-    SDL_free(command_buffer->usedBuffers);
-    SDL_free(command_buffer->usedSamplers);
-    SDL_free(command_buffer->usedGraphicsPipelines);
-    SDL_free(command_buffer->usedComputePipelines);
-    SDL_free(command_buffer->usedUniformBuffers);
-    SDL_free(command_buffer->textureDownloads);
-    SDL_free(command_buffer);
+    SDL_free(commandBuffer->presentDatas);
+    SDL_free(commandBuffer->usedTextures);
+    SDL_free(commandBuffer->usedBuffers);
+    SDL_free(commandBuffer->usedSamplers);
+    SDL_free(commandBuffer->usedGraphicsPipelines);
+    SDL_free(commandBuffer->usedComputePipelines);
+    SDL_free(commandBuffer->usedUniformBuffers);
+    SDL_free(commandBuffer->textureDownloads);
+    SDL_free(commandBuffer);
 }
 
 static void D3D12_INTERNAL_DestroyFence(D3D12Fence *fence)
@@ -1431,15 +1431,15 @@ static void D3D12_DestroyDevice(SDL_GPUDevice *device)
 // Barriers
 
 static inline Uint32 D3D12_INTERNAL_CalcSubresource(
-    Uint32 mip_level,
+    Uint32 mipLevel,
     Uint32 layer,
     Uint32 numLevels)
 {
-    return mip_level + (layer * numLevels);
+    return mipLevel + (layer * numLevels);
 }
 
 static void D3D12_INTERNAL_ResourceBarrier(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES sourceState,
     D3D12_RESOURCE_STATES destinationState,
     ID3D12Resource *resource,
@@ -1471,20 +1471,20 @@ static void D3D12_INTERNAL_ResourceBarrier(
 
     if (numBarriers > 0) {
         ID3D12GraphicsCommandList_ResourceBarrier(
-            command_buffer->graphicsCommandList,
+            commandBuffer->graphicsCommandList,
             numBarriers,
             barrierDesc);
     }
 }
 
 static void D3D12_INTERNAL_TextureSubresourceBarrier(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES sourceState,
     D3D12_RESOURCE_STATES destinationState,
     D3D12TextureSubresource *textureSubresource)
 {
     D3D12_INTERNAL_ResourceBarrier(
-        command_buffer,
+        commandBuffer,
         sourceState,
         destinationState,
         textureSubresource->parent->resource,
@@ -1493,21 +1493,21 @@ static void D3D12_INTERNAL_TextureSubresourceBarrier(
 }
 
 static D3D12_RESOURCE_STATES D3D12_INTERNAL_DefaultTextureResourceState(
-    SDL_GPUTextureUsageFlags usage_flags)
+    SDL_GPUTextureUsageFlags usageFlags)
 {
     // NOTE: order matters here!
 
-    if (usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
+    if (usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
         return D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE;
-    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
         return D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE;
-    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
         return D3D12_RESOURCE_STATE_RENDER_TARGET;
-    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
         return D3D12_RESOURCE_STATE_DEPTH_WRITE;
-    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
         return D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
         return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Texture has no default usage mode!");
@@ -1516,50 +1516,50 @@ static D3D12_RESOURCE_STATES D3D12_INTERNAL_DefaultTextureResourceState(
 }
 
 static void D3D12_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES destinationUsageMode,
     D3D12TextureSubresource *textureSubresource)
 {
     D3D12_INTERNAL_TextureSubresourceBarrier(
-        command_buffer,
+        commandBuffer,
         D3D12_INTERNAL_DefaultTextureResourceState(textureSubresource->parent->container->header.info.usage_flags),
         destinationUsageMode,
         textureSubresource);
 }
 
 static void D3D12_INTERNAL_TextureTransitionFromDefaultUsage(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES destinationUsageMode,
     D3D12Texture *texture)
 {
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         D3D12_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
-            command_buffer,
+            commandBuffer,
             destinationUsageMode,
             &texture->subresources[i]);
     }
 }
 
 static void D3D12_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES sourceUsageMode,
     D3D12TextureSubresource *textureSubresource)
 {
     D3D12_INTERNAL_TextureSubresourceBarrier(
-        command_buffer,
+        commandBuffer,
         sourceUsageMode,
         D3D12_INTERNAL_DefaultTextureResourceState(textureSubresource->parent->container->header.info.usage_flags),
         textureSubresource);
 }
 
 static void D3D12_INTERNAL_TextureTransitionToDefaultUsage(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES sourceUsageMode,
     D3D12Texture *texture)
 {
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         D3D12_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
-            command_buffer,
+            commandBuffer,
             sourceUsageMode,
             &texture->subresources[i]);
     }
@@ -1587,13 +1587,13 @@ static D3D12_RESOURCE_STATES D3D12_INTERNAL_DefaultBufferResourceState(
 }
 
 static void D3D12_INTERNAL_BufferBarrier(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES sourceState,
     D3D12_RESOURCE_STATES destinationState,
     D3D12Buffer *buffer)
 {
     D3D12_INTERNAL_ResourceBarrier(
-        command_buffer,
+        commandBuffer,
         buffer->transitioned ? sourceState : D3D12_RESOURCE_STATE_COMMON,
         destinationState,
         buffer->handle,
@@ -1604,24 +1604,24 @@ static void D3D12_INTERNAL_BufferBarrier(
 }
 
 static void D3D12_INTERNAL_BufferTransitionFromDefaultUsage(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES destinationState,
     D3D12Buffer *buffer)
 {
     D3D12_INTERNAL_BufferBarrier(
-        command_buffer,
+        commandBuffer,
         D3D12_INTERNAL_DefaultBufferResourceState(buffer),
         destinationState,
         buffer);
 }
 
 static void D3D12_INTERNAL_BufferTransitionToDefaultUsage(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_RESOURCE_STATES sourceState,
     D3D12Buffer *buffer)
 {
     D3D12_INTERNAL_BufferBarrier(
-        command_buffer,
+        commandBuffer,
         sourceState,
         D3D12_INTERNAL_DefaultBufferResourceState(buffer),
         buffer);
@@ -1686,10 +1686,10 @@ static void D3D12_INTERNAL_TrackSampler(
 
 static void D3D12_INTERNAL_TrackGraphicsPipeline(
     D3D12CommandBuffer *command_buffer,
-    D3D12GraphicsPipeline *graphics_pipeline)
+    D3D12GraphicsPipeline *graphicsPipeline)
 {
     TRACK_RESOURCE(
-        graphics_pipeline,
+        graphicsPipeline,
         D3D12GraphicsPipeline *,
         usedGraphicsPipelines,
         usedGraphicsPipelineCount,
@@ -1698,10 +1698,10 @@ static void D3D12_INTERNAL_TrackGraphicsPipeline(
 
 static void D3D12_INTERNAL_TrackComputePipeline(
     D3D12CommandBuffer *command_buffer,
-    D3D12ComputePipeline *compute_pipeline)
+    D3D12ComputePipeline *computePipeline)
 {
     TRACK_RESOURCE(
-        compute_pipeline,
+        computePipeline,
         D3D12ComputePipeline *,
         usedComputePipelines,
         usedComputePipelineCount,
@@ -1771,11 +1771,11 @@ static D3D12DescriptorHeap *D3D12_INTERNAL_CreateDescriptorHeap(
 }
 
 static D3D12DescriptorHeap *D3D12_INTERNAL_AcquireDescriptorHeapFromPool(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_DESCRIPTOR_HEAP_TYPE descriptorHeapType)
 {
     D3D12DescriptorHeap *result;
-    D3D12Renderer *renderer = command_buffer->renderer;
+    D3D12Renderer *renderer = commandBuffer->renderer;
     D3D12DescriptorHeapPool *pool = &renderer->descriptorHeapPools[descriptorHeapType];
 
     SDL_LockMutex(pool->lock);
@@ -1835,8 +1835,8 @@ static void D3D12_INTERNAL_ReturnDescriptorHeapToPool(
  */
 static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
     D3D12Renderer *renderer,
-    D3D12Shader *vertex_shader,
-    D3D12Shader *fragment_shader)
+    D3D12Shader *vertexShader,
+    D3D12Shader *fragmentShader)
 {
     // FIXME: I think the max can be smaller...
     D3D12_ROOT_PARAMETER rootParameters[MAX_ROOT_SIGNATURE_PARAMETERS];
@@ -1870,10 +1870,10 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         d3d12GraphicsRootSignature->fragmentUniformBufferRootIndex[i] = -1;
     }
 
-    if (vertex_shader->num_samplers > 0) {
+    if (vertexShader->num_samplers > 0) {
         // Vertex Samplers
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
-        descriptorRange.NumDescriptors = vertex_shader->num_samplers;
+        descriptorRange.NumDescriptors = vertexShader->num_samplers;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -1889,7 +1889,7 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
 
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = vertex_shader->num_samplers;
+        descriptorRange.NumDescriptors = vertexShader->num_samplers;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -1905,11 +1905,11 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (vertex_shader->num_storage_textures) {
+    if (vertexShader->numStorageTextures) {
         // Vertex storage textures
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = vertex_shader->num_storage_textures;
-        descriptorRange.BaseShaderRegister = vertex_shader->num_samplers;
+        descriptorRange.NumDescriptors = vertexShader->numStorageTextures;
+        descriptorRange.BaseShaderRegister = vertexShader->num_samplers;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -1924,12 +1924,12 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (vertex_shader->num_storage_buffers) {
+    if (vertexShader->numStorageBuffers) {
 
         // Vertex storage buffers
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = vertex_shader->num_storage_buffers;
-        descriptorRange.BaseShaderRegister = vertex_shader->num_samplers + vertex_shader->num_storage_textures;
+        descriptorRange.NumDescriptors = vertexShader->numStorageBuffers;
+        descriptorRange.BaseShaderRegister = vertexShader->num_samplers + vertexShader->numStorageTextures;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -1945,7 +1945,7 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
     }
 
     // Vertex Uniforms
-    for (Uint32 i = 0; i < vertex_shader->num_uniform_buffers; i += 1) {
+    for (Uint32 i = 0; i < vertexShader->numUniformBuffers; i += 1) {
         rootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
         rootParameter.Descriptor.ShaderRegister = i;
         rootParameter.Descriptor.RegisterSpace = 1;
@@ -1955,10 +1955,10 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (fragment_shader->num_samplers) {
+    if (fragmentShader->num_samplers) {
         // Fragment Samplers
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
-        descriptorRange.NumDescriptors = fragment_shader->num_samplers;
+        descriptorRange.NumDescriptors = fragmentShader->num_samplers;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 2;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -1974,7 +1974,7 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
 
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = fragment_shader->num_samplers;
+        descriptorRange.NumDescriptors = fragmentShader->num_samplers;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 2;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -1990,11 +1990,11 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (fragment_shader->num_storage_textures) {
+    if (fragmentShader->numStorageTextures) {
         // Fragment Storage Textures
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = fragment_shader->num_storage_textures;
-        descriptorRange.BaseShaderRegister = fragment_shader->num_samplers;
+        descriptorRange.NumDescriptors = fragmentShader->numStorageTextures;
+        descriptorRange.BaseShaderRegister = fragmentShader->num_samplers;
         descriptorRange.RegisterSpace = 2;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -2009,11 +2009,11 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (fragment_shader->num_storage_buffers) {
+    if (fragmentShader->numStorageBuffers) {
         // Fragment Storage Buffers
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = fragment_shader->num_storage_buffers;
-        descriptorRange.BaseShaderRegister = fragment_shader->num_samplers + fragment_shader->num_storage_textures;
+        descriptorRange.NumDescriptors = fragmentShader->numStorageBuffers;
+        descriptorRange.BaseShaderRegister = fragmentShader->num_samplers + fragmentShader->numStorageTextures;
         descriptorRange.RegisterSpace = 2;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -2029,7 +2029,7 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
     }
 
     // Fragment Uniforms
-    for (Uint32 i = 0; i < fragment_shader->num_uniform_buffers; i += 1) {
+    for (Uint32 i = 0; i < fragmentShader->numUniformBuffers; i += 1) {
         rootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
         rootParameter.Descriptor.ShaderRegister = i;
         rootParameter.Descriptor.RegisterSpace = 3;
@@ -2094,18 +2094,18 @@ static bool D3D12_INTERNAL_CreateShaderBytecode(
     Uint32 stage,
     SDL_GPUShaderFormat format,
     const Uint8 *code,
-    size_t code_size,
-    const char *entrypoint_name,
+    size_t codeSize,
+    const char *entrypointName,
     void **pBytecode,
     size_t *pBytecodeSize)
 {
     if (pBytecode != NULL) {
-        *pBytecode = SDL_malloc(code_size);
+        *pBytecode = SDL_malloc(codeSize);
         if (!*pBytecode) {
             return false;
         }
-        SDL_memcpy(*pBytecode, code, code_size);
-        *pBytecodeSize = code_size;
+        SDL_memcpy(*pBytecode, code, codeSize);
+        *pBytecodeSize = codeSize;
     }
 
     return true;
@@ -2322,37 +2322,37 @@ static SDL_GPUComputePipeline *D3D12_CreateComputePipeline(
         return NULL;
     }
 
-    D3D12ComputePipeline *compute_pipeline =
+    D3D12ComputePipeline *computePipeline =
         (D3D12ComputePipeline *)SDL_calloc(1, sizeof(D3D12ComputePipeline));
 
-    if (!compute_pipeline) {
+    if (!computePipeline) {
         ID3D12PipelineState_Release(pipelineState);
         SDL_free(bytecode);
         return NULL;
     }
 
-    compute_pipeline->pipelineState = pipelineState;
-    compute_pipeline->rootSignature = rootSignature;
-    compute_pipeline->num_readonly_storage_textures = createinfo->num_readonly_storage_textures;
-    compute_pipeline->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
-    compute_pipeline->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
-    compute_pipeline->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
-    compute_pipeline->num_uniform_buffers = createinfo->num_uniform_buffers;
-    SDL_AtomicSet(&compute_pipeline->referenceCount, 0);
+    computePipeline->pipelineState = pipelineState;
+    computePipeline->rootSignature = rootSignature;
+    computePipeline->num_readonly_storage_textures = createinfo->num_readonly_storage_textures;
+    computePipeline->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
+    computePipeline->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
+    computePipeline->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
+    computePipeline->numUniformBuffers = createinfo->num_uniform_buffers;
+    SDL_AtomicSet(&computePipeline->referenceCount, 0);
 
-    return (SDL_GPUComputePipeline *)compute_pipeline;
+    return (SDL_GPUComputePipeline *)computePipeline;
 }
 
-static bool D3D12_INTERNAL_ConvertRasterizerState(SDL_GPURasterizerState rasterizer_state, D3D12_RASTERIZER_DESC *desc)
+static bool D3D12_INTERNAL_ConvertRasterizerState(SDL_GPURasterizerState rasterizerState, D3D12_RASTERIZER_DESC *desc)
 {
     if (!desc) {
         return false;
     }
 
-    desc->FillMode = SDLToD3D12_FillMode[rasterizer_state.fill_mode];
-    desc->CullMode = SDLToD3D12_CullMode[rasterizer_state.cull_mode];
+    desc->FillMode = SDLToD3D12_FillMode[rasterizerState.fill_mode];
+    desc->CullMode = SDLToD3D12_CullMode[rasterizerState.cull_mode];
 
-    switch (rasterizer_state.frontFace) {
+    switch (rasterizerState.frontFace) {
     case SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE:
         desc->FrontCounterClockwise = TRUE;
         break;
@@ -2363,10 +2363,10 @@ static bool D3D12_INTERNAL_ConvertRasterizerState(SDL_GPURasterizerState rasteri
         return false;
     }
 
-    if (rasterizer_state.enable_depth_bias) {
-        desc->DepthBias = SDL_lroundf(rasterizer_state.depth_bias_constant_factor);
-        desc->DepthBiasClamp = rasterizer_state.depth_bias_clamp;
-        desc->SlopeScaledDepthBias = rasterizer_state.depth_bias_slope_factor;
+    if (rasterizerState.enable_depth_bias) {
+        desc->DepthBias = SDL_lroundf(rasterizerState.depth_bias_constant_factor);
+        desc->DepthBiasClamp = rasterizerState.depth_bias_clamp;
+        desc->SlopeScaledDepthBias = rasterizerState.depth_bias_slope_factor;
     } else {
         desc->DepthBias = 0;
         desc->DepthBiasClamp = 0.0f;
@@ -2432,48 +2432,48 @@ static bool D3D12_INTERNAL_ConvertBlendState(
     return true;
 }
 
-static bool D3D12_INTERNAL_ConvertDepthStencilState(SDL_GPUDepthStencilState depth_stencil_state, D3D12_DEPTH_STENCIL_DESC *desc)
+static bool D3D12_INTERNAL_ConvertDepthStencilState(SDL_GPUDepthStencilState depthStencilState, D3D12_DEPTH_STENCIL_DESC *desc)
 {
     if (desc == NULL) {
         return false;
     }
 
-    desc->DepthEnable = depth_stencil_state.enable_depth_test == true ? TRUE : FALSE;
-    desc->DepthWriteMask = depth_stencil_state.enable_depth_write == true ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
-    desc->DepthFunc = SDLToD3D12_CompareOp[depth_stencil_state.compare_op];
-    desc->StencilEnable = depth_stencil_state.enable_stencil_test == true ? TRUE : FALSE;
-    desc->StencilReadMask = depth_stencil_state.compare_mask;
-    desc->StencilWriteMask = depth_stencil_state.write_mask;
+    desc->DepthEnable = depthStencilState.enable_depth_test == true ? TRUE : FALSE;
+    desc->DepthWriteMask = depthStencilState.enable_depth_write == true ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
+    desc->DepthFunc = SDLToD3D12_CompareOp[depthStencilState.compare_op];
+    desc->StencilEnable = depthStencilState.enable_stencil_test == true ? TRUE : FALSE;
+    desc->StencilReadMask = depthStencilState.compare_mask;
+    desc->StencilWriteMask = depthStencilState.write_mask;
 
-    desc->FrontFace.StencilFailOp = SDLToD3D12_StencilOp[depth_stencil_state.front_stencil_state.fail_op];
-    desc->FrontFace.StencilDepthFailOp = SDLToD3D12_StencilOp[depth_stencil_state.front_stencil_state.depth_fail_op];
-    desc->FrontFace.StencilPassOp = SDLToD3D12_StencilOp[depth_stencil_state.front_stencil_state.pass_op];
-    desc->FrontFace.StencilFunc = SDLToD3D12_CompareOp[depth_stencil_state.front_stencil_state.compare_op];
+    desc->FrontFace.StencilFailOp = SDLToD3D12_StencilOp[depthStencilState.front_stencil_state.fail_op];
+    desc->FrontFace.StencilDepthFailOp = SDLToD3D12_StencilOp[depthStencilState.front_stencil_state.depth_fail_op];
+    desc->FrontFace.StencilPassOp = SDLToD3D12_StencilOp[depthStencilState.front_stencil_state.pass_op];
+    desc->FrontFace.StencilFunc = SDLToD3D12_CompareOp[depthStencilState.front_stencil_state.compare_op];
 
-    desc->BackFace.StencilFailOp = SDLToD3D12_StencilOp[depth_stencil_state.back_stencil_state.fail_op];
-    desc->BackFace.StencilDepthFailOp = SDLToD3D12_StencilOp[depth_stencil_state.back_stencil_state.depth_fail_op];
-    desc->BackFace.StencilPassOp = SDLToD3D12_StencilOp[depth_stencil_state.back_stencil_state.pass_op];
-    desc->BackFace.StencilFunc = SDLToD3D12_CompareOp[depth_stencil_state.back_stencil_state.compare_op];
+    desc->BackFace.StencilFailOp = SDLToD3D12_StencilOp[depthStencilState.back_stencil_state.fail_op];
+    desc->BackFace.StencilDepthFailOp = SDLToD3D12_StencilOp[depthStencilState.back_stencil_state.depth_fail_op];
+    desc->BackFace.StencilPassOp = SDLToD3D12_StencilOp[depthStencilState.back_stencil_state.pass_op];
+    desc->BackFace.StencilFunc = SDLToD3D12_CompareOp[depthStencilState.back_stencil_state.compare_op];
 
     return true;
 }
 
-static bool D3D12_INTERNAL_ConvertVertexInputState(SDL_GPUVertexInputState vertex_input_state, D3D12_INPUT_ELEMENT_DESC *desc, const char *semantic)
+static bool D3D12_INTERNAL_ConvertVertexInputState(SDL_GPUVertexInputState vertexInputState, D3D12_INPUT_ELEMENT_DESC *desc, const char *semantic)
 {
-    if (desc == NULL || vertex_input_state.num_vertex_attributes == 0) {
+    if (desc == NULL || vertexInputState.num_vertex_attributes == 0) {
         return false;
     }
 
-    for (Uint32 i = 0; i < vertex_input_state.num_vertex_attributes; i += 1) {
-        SDL_GPUVertexAttribute attribute = vertex_input_state.vertex_attributes[i];
+    for (Uint32 i = 0; i < vertexInputState.num_vertex_attributes; i += 1) {
+        SDL_GPUVertexAttribute attribute = vertexInputState.vertex_attributes[i];
 
         desc[i].SemanticName = semantic;
         desc[i].SemanticIndex = attribute.location;
         desc[i].Format = SDLToD3D12_VertexFormat[attribute.format];
         desc[i].InputSlot = attribute.binding;
         desc[i].AlignedByteOffset = attribute.offset;
-        desc[i].InputSlotClass = SDLToD3D12_InputRate[vertex_input_state.vertex_bindings[attribute.binding].input_rate];
-        desc[i].InstanceDataStepRate = (vertex_input_state.vertex_bindings[attribute.binding].input_rate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) ? vertex_input_state.vertex_bindings[attribute.binding].instance_step_rate : 0;
+        desc[i].InputSlotClass = SDLToD3D12_InputRate[vertexInputState.vertex_bindings[attribute.binding].input_rate];
+        desc[i].InstanceDataStepRate = (vertexInputState.vertex_bindings[attribute.binding].input_rate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) ? vertexInputState.vertex_bindings[attribute.binding].instance_step_rate : 0;
     }
 
     return true;
@@ -2599,17 +2599,17 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
         pipeline->vertexStrides[i] = createinfo->vertex_input_state.vertex_bindings[i].pitch;
     }
 
-    pipeline->primitive_type = createinfo->primitive_type;
+    pipeline->primitiveType = createinfo->primitive_type;
 
     pipeline->vertexSamplerCount = vertShader->num_samplers;
-    pipeline->vertexStorageTextureCount = vertShader->num_storage_textures;
-    pipeline->vertexStorageBufferCount = vertShader->num_storage_buffers;
-    pipeline->vertexUniformBufferCount = vertShader->num_uniform_buffers;
+    pipeline->vertexStorageTextureCount = vertShader->numStorageTextures;
+    pipeline->vertexStorageBufferCount = vertShader->numStorageBuffers;
+    pipeline->vertexUniformBufferCount = vertShader->numUniformBuffers;
 
     pipeline->fragmentSamplerCount = fragShader->num_samplers;
-    pipeline->fragmentStorageTextureCount = fragShader->num_storage_textures;
-    pipeline->fragmentStorageBufferCount = fragShader->num_storage_buffers;
-    pipeline->fragmentUniformBufferCount = fragShader->num_uniform_buffers;
+    pipeline->fragmentStorageTextureCount = fragShader->numStorageTextures;
+    pipeline->fragmentStorageBufferCount = fragShader->numStorageBuffers;
+    pipeline->fragmentUniformBufferCount = fragShader->numUniformBuffers;
 
     SDL_AtomicSet(&pipeline->referenceCount, 0);
     return (SDL_GPUGraphicsPipeline *)pipeline;
@@ -2686,9 +2686,9 @@ static SDL_GPUShader *D3D12_CreateShader(
         return NULL;
     }
     shader->num_samplers = createinfo->num_samplers;
-    shader->num_storage_buffers = createinfo->num_storage_buffers;
-    shader->num_storage_textures = createinfo->num_storage_textures;
-    shader->num_uniform_buffers = createinfo->num_uniform_buffers;
+    shader->numStorageBuffers = createinfo->num_storage_buffers;
+    shader->numStorageTextures = createinfo->num_storage_textures;
+    shader->numUniformBuffers = createinfo->num_uniform_buffers;
 
     shader->bytecode = bytecode;
     shader->bytecodeSize = bytecodeSize;
@@ -3012,7 +3012,7 @@ static SDL_GPUTexture *D3D12_CreateTexture(
 
 static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
     D3D12Renderer *renderer,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     Uint32 size,
     D3D12BufferType type)
 {
@@ -3034,7 +3034,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
         return NULL;
     }
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         resourceFlags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     }
 #if (defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES))
@@ -3115,7 +3115,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
     buffer->srvDescriptor.heap = NULL;
     buffer->cbvDescriptor.heap = NULL;
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         D3D12_INTERNAL_AssignCpuDescriptorHandle(
             renderer,
             D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
@@ -3139,8 +3139,8 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
     }
 
     if (
-        (usage_flags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) ||
-        (usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ)) {
+        (usageFlags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) ||
+        (usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ)) {
         D3D12_INTERNAL_AssignCpuDescriptorHandle(
             renderer,
             D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
@@ -3209,7 +3209,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
 
 static D3D12BufferContainer *D3D12_INTERNAL_CreateBufferContainer(
     D3D12Renderer *renderer,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     Uint32 size,
     D3D12BufferType type)
 {
@@ -3221,7 +3221,7 @@ static D3D12BufferContainer *D3D12_INTERNAL_CreateBufferContainer(
         return NULL;
     }
 
-    container->usage_flags = usage_flags;
+    container->usage_flags = usageFlags;
     container->size = size;
     container->type = type;
 
@@ -3237,7 +3237,7 @@ static D3D12BufferContainer *D3D12_INTERNAL_CreateBufferContainer(
 
     buffer = D3D12_INTERNAL_CreateBuffer(
         renderer,
-        usage_flags,
+        usageFlags,
         size,
         type);
 
@@ -3258,12 +3258,12 @@ static D3D12BufferContainer *D3D12_INTERNAL_CreateBufferContainer(
 
 static SDL_GPUBuffer *D3D12_CreateBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     Uint32 size)
 {
     return (SDL_GPUBuffer *)D3D12_INTERNAL_CreateBufferContainer(
         (D3D12Renderer *)driverData,
-        usage_flags,
+        usageFlags,
         size,
         D3D12_BUFFER_TYPE_GPU);
 }
@@ -3346,11 +3346,11 @@ static bool D3D12_INTERNAL_StrToWStr(
     D3D12Renderer *renderer,
     const char *str,
     wchar_t *wstr,
-    size_t wstr_size,
+    size_t wstrSize,
     Uint32 *outSize)
 {
     size_t inlen, result;
-    size_t outlen = wstr_size;
+    size_t outlen = wstrSize;
 
     if (renderer->iconv == NULL) {
         renderer->iconv = SDL_iconv_open("WCHAR_T", "UTF-8");
@@ -3384,10 +3384,10 @@ static bool D3D12_INTERNAL_StrToWStr(
 }
 
 static void D3D12_InsertDebugLabel(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *text)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     wchar_t wstr[256];
     Uint32 convSize;
 
@@ -3408,10 +3408,10 @@ static void D3D12_InsertDebugLabel(
 }
 
 static void D3D12_PushDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *name)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     wchar_t wstr[256];
     Uint32 convSize;
 
@@ -3432,9 +3432,9 @@ static void D3D12_PushDebugGroup(
 }
 
 static void D3D12_PopDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     ID3D12GraphicsCommandList_EndEvent(d3d12CommandBuffer->graphicsCommandList);
 }
 
@@ -3488,10 +3488,10 @@ static void D3D12_ReleaseBuffer(
 
 static void D3D12_ReleaseTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)transfer_buffer;
+    D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)transferBuffer;
 
     D3D12_INTERNAL_ReleaseBufferContainer(
         renderer,
@@ -3514,10 +3514,10 @@ static void D3D12_ReleaseShader(
 
 static void D3D12_ReleaseComputePipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUComputePipeline *computePipeline)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12ComputePipeline *d3d12ComputePipeline = (D3D12ComputePipeline *)compute_pipeline;
+    D3D12ComputePipeline *d3d12ComputePipeline = (D3D12ComputePipeline *)computePipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -3536,10 +3536,10 @@ static void D3D12_ReleaseComputePipeline(
 
 static void D3D12_ReleaseGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12GraphicsPipeline *d3d12GraphicsPipeline = (D3D12GraphicsPipeline *)graphics_pipeline;
+    D3D12GraphicsPipeline *d3d12GraphicsPipeline = (D3D12GraphicsPipeline *)graphicsPipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -3576,10 +3576,10 @@ static void D3D12_INTERNAL_ReleaseBlitPipelines(SDL_GPURenderer *driverData)
 // Render Pass
 
 static void D3D12_SetViewport(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUViewport *viewport)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12_VIEWPORT d3d12Viewport;
     d3d12Viewport.TopLeftX = viewport->x;
     d3d12Viewport.TopLeftY = viewport->y;
@@ -3591,10 +3591,10 @@ static void D3D12_SetViewport(
 }
 
 static void D3D12_SetScissor(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_Rect *scissor)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12_RECT scissorRect;
     scissorRect.left = scissor->x;
     scissorRect.top = scissor->y;
@@ -3604,19 +3604,19 @@ static void D3D12_SetScissor(
 }
 
 static void D3D12_SetBlendConstants(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_FColor blend_constants)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_FColor blendConstants)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
-    FLOAT blendFactor[4] = { blend_constants.r, blend_constants.g, blend_constants.b, blend_constants.a };
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    FLOAT blendFactor[4] = { blendConstants.r, blendConstants.g, blendConstants.b, blendConstants.a };
     ID3D12GraphicsCommandList_OMSetBlendFactor(d3d12CommandBuffer->graphicsCommandList, blendFactor);
 }
 
 static void D3D12_SetStencilReference(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     Uint8 reference
 ) {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     ID3D12GraphicsCommandList_OMSetStencilRef(d3d12CommandBuffer->graphicsCommandList, reference);
 }
 
@@ -3682,7 +3682,7 @@ static void D3D12_INTERNAL_CycleActiveTexture(
 }
 
 static D3D12TextureSubresource *D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12TextureContainer *container,
     Uint32 layer,
     Uint32 level,
@@ -3699,7 +3699,7 @@ static D3D12TextureSubresource *D3D12_INTERNAL_PrepareTextureSubresourceForWrite
         cycle &&
         SDL_AtomicGet(&subresource->parent->referenceCount) > 0) {
         D3D12_INTERNAL_CycleActiveTexture(
-            command_buffer->renderer,
+            commandBuffer->renderer,
             container);
 
         subresource = D3D12_INTERNAL_FetchTextureSubresource(
@@ -3709,7 +3709,7 @@ static D3D12TextureSubresource *D3D12_INTERNAL_PrepareTextureSubresourceForWrite
     }
 
     D3D12_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
-        command_buffer,
+        commandBuffer,
         destinationUsageMode,
         subresource);
 
@@ -3764,7 +3764,7 @@ static void D3D12_INTERNAL_CycleActiveBuffer(
 }
 
 static D3D12Buffer *D3D12_INTERNAL_PrepareBufferForWrite(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12BufferContainer *container,
     bool cycle,
     D3D12_RESOURCE_STATES destinationState)
@@ -3773,12 +3773,12 @@ static D3D12Buffer *D3D12_INTERNAL_PrepareBufferForWrite(
         cycle &&
         SDL_AtomicGet(&container->activeBuffer->referenceCount) > 0) {
         D3D12_INTERNAL_CycleActiveBuffer(
-            command_buffer->renderer,
+            commandBuffer->renderer,
             container);
     }
 
     D3D12_INTERNAL_BufferTransitionFromDefaultUsage(
-        command_buffer,
+        commandBuffer,
         destinationState,
         container->activeBuffer);
 
@@ -3786,20 +3786,20 @@ static D3D12Buffer *D3D12_INTERNAL_PrepareBufferForWrite(
 }
 
 static void D3D12_BeginRenderPass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
+    Uint32 numColorAttachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
     Uint32 framebufferWidth = SDL_MAX_UINT32;
     Uint32 framebufferHeight = SDL_MAX_UINT32;
 
-    for (Uint32 i = 0; i < num_color_attachments; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)color_attachment_infos[i].texture;
-        Uint32 h = container->header.info.height >> color_attachment_infos[i].mip_level;
-        Uint32 w = container->header.info.width >> color_attachment_infos[i].mip_level;
+    for (Uint32 i = 0; i < numColorAttachments; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)colorAttachmentInfos[i].texture;
+        Uint32 h = container->header.info.height >> colorAttachmentInfos[i].mip_level;
+        Uint32 w = container->header.info.width >> colorAttachmentInfos[i].mip_level;
 
         // The framebuffer cannot be larger than the smallest attachment.
 
@@ -3817,8 +3817,8 @@ static void D3D12_BeginRenderPass(
         }
     }
 
-    if (depth_stencil_attachment_info != NULL) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)depth_stencil_attachment_info->texture;
+    if (depthStencilAttachmentInfo != NULL) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)depthStencilAttachmentInfo->texture;
 
         Uint32 h = container->header.info.height;
         Uint32 w = container->header.info.width;
@@ -3842,31 +3842,31 @@ static void D3D12_BeginRenderPass(
 
     D3D12_CPU_DESCRIPTOR_HANDLE rtvs[MAX_COLOR_TARGET_BINDINGS];
 
-    for (Uint32 i = 0; i < num_color_attachments; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)color_attachment_infos[i].texture;
+    for (Uint32 i = 0; i < numColorAttachments; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)colorAttachmentInfos[i].texture;
         D3D12TextureSubresource *subresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
             d3d12CommandBuffer,
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level,
-            color_attachment_infos[i].cycle,
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layer_or_depth_plane,
+            colorAttachmentInfos[i].mip_level,
+            colorAttachmentInfos[i].cycle,
             D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-        Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
+        Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layer_or_depth_plane : 0;
         D3D12_CPU_DESCRIPTOR_HANDLE rtv =
             subresource->rtvHandles[rtvIndex].cpuHandle;
 
-        if (color_attachment_infos[i].load_op == SDL_GPU_LOADOP_CLEAR) {
-            float clear_color[4];
-            clear_color[0] = color_attachment_infos[i].clear_color.r;
-            clear_color[1] = color_attachment_infos[i].clear_color.g;
-            clear_color[2] = color_attachment_infos[i].clear_color.b;
-            clear_color[3] = color_attachment_infos[i].clear_color.a;
+        if (colorAttachmentInfos[i].load_op == SDL_GPU_LOADOP_CLEAR) {
+            float clearColor[4];
+            clearColor[0] = colorAttachmentInfos[i].clear_color.r;
+            clearColor[1] = colorAttachmentInfos[i].clear_color.g;
+            clearColor[2] = colorAttachmentInfos[i].clear_color.b;
+            clearColor[3] = colorAttachmentInfos[i].clear_color.a;
 
             ID3D12GraphicsCommandList_ClearRenderTargetView(
                 d3d12CommandBuffer->graphicsCommandList,
                 rtv,
-                clear_color,
+                clearColor,
                 0,
                 NULL);
         }
@@ -3877,27 +3877,27 @@ static void D3D12_BeginRenderPass(
         D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, subresource->parent);
     }
 
-    d3d12CommandBuffer->colorAttachmentTextureSubresourceCount = num_color_attachments;
+    d3d12CommandBuffer->colorAttachmentTextureSubresourceCount = numColorAttachments;
 
     D3D12_CPU_DESCRIPTOR_HANDLE dsv;
-    if (depth_stencil_attachment_info != NULL) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)depth_stencil_attachment_info->texture;
+    if (depthStencilAttachmentInfo != NULL) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)depthStencilAttachmentInfo->texture;
         D3D12TextureSubresource *subresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
             d3d12CommandBuffer,
             container,
             0,
             0,
-            depth_stencil_attachment_info->cycle,
+            depthStencilAttachmentInfo->cycle,
             D3D12_RESOURCE_STATE_DEPTH_WRITE);
 
         if (
-            depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_CLEAR ||
-            depth_stencil_attachment_info->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
+            depthStencilAttachmentInfo->load_op == SDL_GPU_LOADOP_CLEAR ||
+            depthStencilAttachmentInfo->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
             D3D12_CLEAR_FLAGS clearFlags = (D3D12_CLEAR_FLAGS)0;
-            if (depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_CLEAR) {
+            if (depthStencilAttachmentInfo->load_op == SDL_GPU_LOADOP_CLEAR) {
                 clearFlags |= D3D12_CLEAR_FLAG_DEPTH;
             }
-            if (depth_stencil_attachment_info->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
+            if (depthStencilAttachmentInfo->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
                 clearFlags |= D3D12_CLEAR_FLAG_STENCIL;
             }
 
@@ -3905,8 +3905,8 @@ static void D3D12_BeginRenderPass(
                 d3d12CommandBuffer->graphicsCommandList,
                 subresource->dsvHandle.cpuHandle,
                 clearFlags,
-                depth_stencil_attachment_info->clear_value.depth,
-                depth_stencil_attachment_info->clear_value.stencil,
+                depthStencilAttachmentInfo->clear_value.depth,
+                depthStencilAttachmentInfo->clear_value.stencil,
                 0,
                 NULL);
         }
@@ -3918,10 +3918,10 @@ static void D3D12_BeginRenderPass(
 
     ID3D12GraphicsCommandList_OMSetRenderTargets(
         d3d12CommandBuffer->graphicsCommandList,
-        num_color_attachments,
+        numColorAttachments,
         rtvs,
         false,
-        (depth_stencil_attachment_info == NULL) ? NULL : &dsv);
+        (depthStencilAttachmentInfo == NULL) ? NULL : &dsv);
 
     // Set sensible default states
     SDL_GPUViewport defaultViewport;
@@ -3933,7 +3933,7 @@ static void D3D12_BeginRenderPass(
     defaultViewport.maxDepth = 1;
 
     D3D12_SetViewport(
-        command_buffer,
+        commandBuffer,
         &defaultViewport);
 
     SDL_Rect defaultScissor;
@@ -3943,48 +3943,48 @@ static void D3D12_BeginRenderPass(
     defaultScissor.h = (Sint32)framebufferHeight;
 
     D3D12_SetScissor(
-        command_buffer,
+        commandBuffer,
         &defaultScissor);
 
     D3D12_SetStencilReference(
-        command_buffer,
+        commandBuffer,
         0);
 
     D3D12_SetBlendConstants(
-        command_buffer,
+        commandBuffer,
         (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
 }
 
 static void D3D12_INTERNAL_TrackUniformBuffer(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12UniformBuffer *uniformBuffer)
 {
     Uint32 i;
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
-        if (command_buffer->usedUniformBuffers[i] == uniformBuffer) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
+        if (commandBuffer->usedUniformBuffers[i] == uniformBuffer) {
             return;
         }
     }
 
-    if (command_buffer->usedUniformBufferCount == command_buffer->usedUniformBufferCapacity) {
-        command_buffer->usedUniformBufferCapacity += 1;
-        command_buffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_realloc(
-            command_buffer->usedUniformBuffers,
-            command_buffer->usedUniformBufferCapacity * sizeof(D3D12UniformBuffer *));
+    if (commandBuffer->usedUniformBufferCount == commandBuffer->usedUniformBufferCapacity) {
+        commandBuffer->usedUniformBufferCapacity += 1;
+        commandBuffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_realloc(
+            commandBuffer->usedUniformBuffers,
+            commandBuffer->usedUniformBufferCapacity * sizeof(D3D12UniformBuffer *));
     }
 
-    command_buffer->usedUniformBuffers[command_buffer->usedUniformBufferCount] = uniformBuffer;
-    command_buffer->usedUniformBufferCount += 1;
+    commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
+    commandBuffer->usedUniformBufferCount += 1;
 
     D3D12_INTERNAL_TrackBuffer(
-        command_buffer,
+        commandBuffer,
         uniformBuffer->buffer);
 }
 
 static D3D12UniformBuffer *D3D12_INTERNAL_AcquireUniformBufferFromPool(
-    D3D12CommandBuffer *command_buffer)
+    D3D12CommandBuffer *commandBuffer)
 {
-    D3D12Renderer *renderer = command_buffer->renderer;
+    D3D12Renderer *renderer = commandBuffer->renderer;
     D3D12UniformBuffer *uniformBuffer;
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
@@ -4023,7 +4023,7 @@ static D3D12UniformBuffer *D3D12_INTERNAL_AcquireUniformBufferFromPool(
         (void **)&uniformBuffer->buffer->mapPointer);
     ERROR_CHECK_RETURN("Failed to map buffer pool!", NULL);
 
-    D3D12_INTERNAL_TrackUniformBuffer(command_buffer, uniformBuffer);
+    D3D12_INTERNAL_TrackUniformBuffer(commandBuffer, uniformBuffer);
 
     return uniformBuffer;
 }
@@ -4044,32 +4044,32 @@ static void D3D12_INTERNAL_ReturnUniformBufferToPool(
 }
 
 static void D3D12_INTERNAL_PushUniformData(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     SDL_GPUShaderStage shaderStage,
-    Uint32 slot_index,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     D3D12UniformBuffer *uniformBuffer;
 
     if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-        if (command_buffer->vertexUniformBuffers[slot_index] == NULL) {
-            command_buffer->vertexUniformBuffers[slot_index] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->vertexUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->vertexUniformBuffers[slotIndex] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->vertexUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->vertexUniformBuffers[slotIndex];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-        if (command_buffer->fragmentUniformBuffers[slot_index] == NULL) {
-            command_buffer->fragmentUniformBuffers[slot_index] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->fragmentUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->fragmentUniformBuffers[slotIndex] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->fragmentUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->fragmentUniformBuffers[slotIndex];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-        if (command_buffer->computeUniformBuffers[slot_index] == NULL) {
-            command_buffer->computeUniformBuffers[slot_index] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->computeUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->computeUniformBuffers[slotIndex] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->computeUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->computeUniformBuffers[slotIndex];
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -4088,17 +4088,17 @@ static void D3D12_INTERNAL_PushUniformData(
             NULL);
         uniformBuffer->buffer->mapPointer = NULL;
 
-        uniformBuffer = D3D12_INTERNAL_AcquireUniformBufferFromPool(command_buffer);
+        uniformBuffer = D3D12_INTERNAL_AcquireUniformBufferFromPool(commandBuffer);
 
         uniformBuffer->drawOffset = 0;
         uniformBuffer->writeOffset = 0;
 
         if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-            command_buffer->vertexUniformBuffers[slot_index] = uniformBuffer;
+            commandBuffer->vertexUniformBuffers[slotIndex] = uniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-            command_buffer->fragmentUniformBuffers[slot_index] = uniformBuffer;
+            commandBuffer->fragmentUniformBuffers[slotIndex] = uniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-            command_buffer->computeUniformBuffers[slot_index] = uniformBuffer;
+            commandBuffer->computeUniformBuffers[slotIndex] = uniformBuffer;
         } else {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         }
@@ -4114,22 +4114,22 @@ static void D3D12_INTERNAL_PushUniformData(
     uniformBuffer->writeOffset += uniformBuffer->currentBlockSize;
 
     if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-        command_buffer->needVertexUniformBufferBind[slot_index] = true;
+        commandBuffer->needVertexUniformBufferBind[slotIndex] = true;
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-        command_buffer->needFragmentUniformBufferBind[slot_index] = true;
+        commandBuffer->needFragmentUniformBufferBind[slotIndex] = true;
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-        command_buffer->needComputeUniformBufferBind[slot_index] = true;
+        commandBuffer->needComputeUniformBufferBind[slotIndex] = true;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
     }
 }
 
 static void D3D12_BindGraphicsPipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
-    D3D12GraphicsPipeline *pipeline = (D3D12GraphicsPipeline *)graphics_pipeline;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12GraphicsPipeline *pipeline = (D3D12GraphicsPipeline *)graphicsPipeline;
     Uint32 i;
 
     d3d12CommandBuffer->currentGraphicsPipeline = pipeline;
@@ -4137,7 +4137,7 @@ static void D3D12_BindGraphicsPipeline(
     // Set the pipeline state
     ID3D12GraphicsCommandList_SetPipelineState(d3d12CommandBuffer->graphicsCommandList, pipeline->pipelineState);
     ID3D12GraphicsCommandList_SetGraphicsRootSignature(d3d12CommandBuffer->graphicsCommandList, pipeline->rootSignature->handle);
-    ID3D12GraphicsCommandList_IASetPrimitiveTopology(d3d12CommandBuffer->graphicsCommandList, SDLToD3D12_PrimitiveType[pipeline->primitive_type]);
+    ID3D12GraphicsCommandList_IASetPrimitiveTopology(d3d12CommandBuffer->graphicsCommandList, SDLToD3D12_PrimitiveType[pipeline->primitiveType]);
 
     // Mark that bindings are needed
     d3d12CommandBuffer->needVertexSamplerBind = true;
@@ -4170,32 +4170,32 @@ static void D3D12_BindGraphicsPipeline(
 }
 
 static void D3D12_BindVertexBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_binding,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstBinding,
     const SDL_GPUBufferBinding *bindings,
-    Uint32 num_bindings)
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
+    for (Uint32 i = 0; i < numBindings; i += 1) {
         D3D12Buffer *currentBuffer = ((D3D12BufferContainer *)bindings[i].buffer)->activeBuffer;
-        d3d12CommandBuffer->vertexBuffers[first_binding + i] = currentBuffer;
-        d3d12CommandBuffer->vertexBufferOffsets[first_binding + i] = bindings[i].offset;
+        d3d12CommandBuffer->vertexBuffers[firstBinding + i] = currentBuffer;
+        d3d12CommandBuffer->vertexBufferOffsets[firstBinding + i] = bindings[i].offset;
         D3D12_INTERNAL_TrackBuffer(d3d12CommandBuffer, currentBuffer);
     }
 
     d3d12CommandBuffer->vertexBufferCount =
-        SDL_max(d3d12CommandBuffer->vertexBufferCount, first_binding + num_bindings);
+        SDL_max(d3d12CommandBuffer->vertexBufferCount, firstBinding + numBindings);
 
     d3d12CommandBuffer->needVertexBufferBind = true;
 }
 
 static void D3D12_BindIndexBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize index_element_size)
+    SDL_GPUIndexElementSize indexElementSize)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Buffer *buffer = ((D3D12BufferContainer *)pBinding->buffer)->activeBuffer;
     D3D12_INDEX_BUFFER_VIEW view;
 
@@ -4204,7 +4204,7 @@ static void D3D12_BindIndexBuffer(
     view.BufferLocation = buffer->virtualAddress + pBinding->offset;
     view.SizeInBytes = buffer->container->size - pBinding->offset;
     view.Format =
-        index_element_size == SDL_GPU_INDEXELEMENTSIZE_16BIT ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT;
+        indexElementSize == SDL_GPU_INDEXELEMENTSIZE_16BIT ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT;
 
     ID3D12GraphicsCommandList_IASetIndexBuffer(
         d3d12CommandBuffer->graphicsCommandList,
@@ -4212,16 +4212,16 @@ static void D3D12_BindIndexBuffer(
 }
 
 static void D3D12_BindVertexSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)texture_sampler_bindings[i].texture;
-        D3D12Sampler *sampler = (D3D12Sampler *)texture_sampler_bindings[i].sampler;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)textureSamplerBindings[i].texture;
+        D3D12Sampler *sampler = (D3D12Sampler *)textureSamplerBindings[i].sampler;
 
         D3D12_INTERNAL_TrackTexture(
             d3d12CommandBuffer,
@@ -4231,65 +4231,65 @@ static void D3D12_BindVertexSamplers(
             d3d12CommandBuffer,
             sampler);
 
-        d3d12CommandBuffer->vertexSamplers[first_slot + i] = sampler;
-        d3d12CommandBuffer->vertexSamplerTextures[first_slot + i] = container->activeTexture;
+        d3d12CommandBuffer->vertexSamplers[firstSlot + i] = sampler;
+        d3d12CommandBuffer->vertexSamplerTextures[firstSlot + i] = container->activeTexture;
     }
 
     d3d12CommandBuffer->needVertexSamplerBind = true;
 }
 
 static void D3D12_BindVertexStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)storageTextures[i];
         D3D12Texture *texture = container->activeTexture;
 
         D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, texture);
 
-        d3d12CommandBuffer->vertexStorageTextures[first_slot + i] = texture;
+        d3d12CommandBuffer->vertexStorageTextures[firstSlot + i] = texture;
     }
 
     d3d12CommandBuffer->needVertexStorageTextureBind = true;
 }
 
 static void D3D12_BindVertexStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D12BufferContainer *container = (D3D12BufferContainer *)storage_buffers[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D12BufferContainer *container = (D3D12BufferContainer *)storageBuffers[i];
 
         D3D12_INTERNAL_TrackBuffer(
             d3d12CommandBuffer,
             container->activeBuffer);
 
-        d3d12CommandBuffer->vertexStorageBuffers[first_slot + i] = container->activeBuffer;
+        d3d12CommandBuffer->vertexStorageBuffers[firstSlot + i] = container->activeBuffer;
     }
 
     d3d12CommandBuffer->needVertexStorageBufferBind = true;
 }
 
 static void D3D12_BindFragmentSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)texture_sampler_bindings[i].texture;
-        D3D12Sampler *sampler = (D3D12Sampler *)texture_sampler_bindings[i].sampler;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)textureSamplerBindings[i].texture;
+        D3D12Sampler *sampler = (D3D12Sampler *)textureSamplerBindings[i].sampler;
 
         D3D12_INTERNAL_TrackTexture(
             d3d12CommandBuffer,
@@ -4299,94 +4299,94 @@ static void D3D12_BindFragmentSamplers(
             d3d12CommandBuffer,
             sampler);
 
-        d3d12CommandBuffer->fragmentSamplers[first_slot + i] = sampler;
-        d3d12CommandBuffer->fragmentSamplerTextures[first_slot + i] = container->activeTexture;
+        d3d12CommandBuffer->fragmentSamplers[firstSlot + i] = sampler;
+        d3d12CommandBuffer->fragmentSamplerTextures[firstSlot + i] = container->activeTexture;
     }
 
     d3d12CommandBuffer->needFragmentSamplerBind = true;
 }
 
 static void D3D12_BindFragmentStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)storageTextures[i];
         D3D12Texture *texture = container->activeTexture;
 
         D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, texture);
 
-        d3d12CommandBuffer->fragmentStorageTextures[first_slot + i] = texture;
+        d3d12CommandBuffer->fragmentStorageTextures[firstSlot + i] = texture;
     }
 
     d3d12CommandBuffer->needFragmentStorageTextureBind = true;
 }
 
 static void D3D12_BindFragmentStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        D3D12BufferContainer *container = (D3D12BufferContainer *)storage_buffers[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        D3D12BufferContainer *container = (D3D12BufferContainer *)storageBuffers[i];
 
         D3D12_INTERNAL_TrackBuffer(
             d3d12CommandBuffer,
             container->activeBuffer);
 
-        d3d12CommandBuffer->fragmentStorageBuffers[first_slot + i] = container->activeBuffer;
+        d3d12CommandBuffer->fragmentStorageBuffers[firstSlot + i] = container->activeBuffer;
     }
 
     d3d12CommandBuffer->needFragmentStorageBufferBind = true;
 }
 
 static void D3D12_PushVertexUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
     D3D12_INTERNAL_PushUniformData(
         d3d12CommandBuffer,
         SDL_GPU_SHADERSTAGE_VERTEX,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void D3D12_PushFragmentUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
     D3D12_INTERNAL_PushUniformData(
         d3d12CommandBuffer,
         SDL_GPU_SHADERSTAGE_FRAGMENT,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void D3D12_INTERNAL_WriteGPUDescriptors(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12_DESCRIPTOR_HEAP_TYPE heapType,
     D3D12_CPU_DESCRIPTOR_HANDLE *resourceDescriptorHandles,
     Uint32 resourceHandleCount,
     D3D12_GPU_DESCRIPTOR_HANDLE *gpuBaseDescriptor)
 {
-    D3D12DescriptorHeap *heap = command_buffer->gpuDescriptorHeaps[heapType];
+    D3D12DescriptorHeap *heap = commandBuffer->gpuDescriptorHeaps[heapType];
     D3D12_CPU_DESCRIPTOR_HANDLE gpuHeapCpuHandle;
 
     // FIXME: need to error on overflow
@@ -4395,7 +4395,7 @@ static void D3D12_INTERNAL_WriteGPUDescriptors(
 
     for (Uint32 i = 0; i < resourceHandleCount; i += 1) {
         ID3D12Device_CopyDescriptorsSimple(
-            command_buffer->renderer->device,
+            commandBuffer->renderer->device,
             1,
             gpuHeapCpuHandle,
             resourceDescriptorHandles[i],
@@ -4407,257 +4407,257 @@ static void D3D12_INTERNAL_WriteGPUDescriptors(
 }
 
 static void D3D12_INTERNAL_BindGraphicsResources(
-    D3D12CommandBuffer *command_buffer)
+    D3D12CommandBuffer *commandBuffer)
 {
-    D3D12GraphicsPipeline *graphics_pipeline = command_buffer->currentGraphicsPipeline;
+    D3D12GraphicsPipeline *graphicsPipeline = commandBuffer->currentGraphicsPipeline;
 
     D3D12_CPU_DESCRIPTOR_HANDLE cpuHandles[MAX_TEXTURE_SAMPLERS_PER_STAGE];
     D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
     D3D12_VERTEX_BUFFER_VIEW vertexBufferViews[MAX_BUFFER_BINDINGS];
 
-    if (command_buffer->needVertexBufferBind) {
-        for (Uint32 i = 0; i < command_buffer->vertexBufferCount; i += 1) {
-            vertexBufferViews[i].BufferLocation = command_buffer->vertexBuffers[i]->virtualAddress + command_buffer->vertexBufferOffsets[i];
-            vertexBufferViews[i].SizeInBytes = command_buffer->vertexBuffers[i]->container->size - command_buffer->vertexBufferOffsets[i];
-            vertexBufferViews[i].StrideInBytes = graphics_pipeline->vertexStrides[i];
+    if (commandBuffer->needVertexBufferBind) {
+        for (Uint32 i = 0; i < commandBuffer->vertexBufferCount; i += 1) {
+            vertexBufferViews[i].BufferLocation = commandBuffer->vertexBuffers[i]->virtualAddress + commandBuffer->vertexBufferOffsets[i];
+            vertexBufferViews[i].SizeInBytes = commandBuffer->vertexBuffers[i]->container->size - commandBuffer->vertexBufferOffsets[i];
+            vertexBufferViews[i].StrideInBytes = graphicsPipeline->vertexStrides[i];
         }
 
         ID3D12GraphicsCommandList_IASetVertexBuffers(
-            command_buffer->graphicsCommandList,
+            commandBuffer->graphicsCommandList,
             0,
-            command_buffer->vertexBufferCount,
+            commandBuffer->vertexBufferCount,
             vertexBufferViews);
     }
 
-    if (command_buffer->needVertexSamplerBind) {
-        if (graphics_pipeline->vertexSamplerCount > 0) {
-            for (Uint32 i = 0; i < graphics_pipeline->vertexSamplerCount; i += 1) {
-                cpuHandles[i] = command_buffer->vertexSamplers[i]->handle.cpuHandle;
+    if (commandBuffer->needVertexSamplerBind) {
+        if (graphicsPipeline->vertexSamplerCount > 0) {
+            for (Uint32 i = 0; i < graphicsPipeline->vertexSamplerCount; i += 1) {
+                cpuHandles[i] = commandBuffer->vertexSamplers[i]->handle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
                 cpuHandles,
-                graphics_pipeline->vertexSamplerCount,
+                graphicsPipeline->vertexSamplerCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                graphics_pipeline->rootSignature->vertexSamplerRootIndex,
+                commandBuffer->graphicsCommandList,
+                graphicsPipeline->rootSignature->vertexSamplerRootIndex,
                 gpuDescriptorHandle);
 
-            for (Uint32 i = 0; i < graphics_pipeline->vertexSamplerCount; i += 1) {
-                cpuHandles[i] = command_buffer->vertexSamplerTextures[i]->srvHandle.cpuHandle;
+            for (Uint32 i = 0; i < graphicsPipeline->vertexSamplerCount; i += 1) {
+                cpuHandles[i] = commandBuffer->vertexSamplerTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphics_pipeline->vertexSamplerCount,
+                graphicsPipeline->vertexSamplerCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                graphics_pipeline->rootSignature->vertexSamplerTextureRootIndex,
+                commandBuffer->graphicsCommandList,
+                graphicsPipeline->rootSignature->vertexSamplerTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        command_buffer->needVertexSamplerBind = false;
+        commandBuffer->needVertexSamplerBind = false;
     }
 
-    if (command_buffer->needVertexStorageTextureBind) {
-        if (graphics_pipeline->vertexStorageTextureCount > 0) {
-            for (Uint32 i = 0; i < graphics_pipeline->vertexStorageTextureCount; i += 1) {
-                cpuHandles[i] = command_buffer->vertexStorageTextures[i]->srvHandle.cpuHandle;
+    if (commandBuffer->needVertexStorageTextureBind) {
+        if (graphicsPipeline->vertexStorageTextureCount > 0) {
+            for (Uint32 i = 0; i < graphicsPipeline->vertexStorageTextureCount; i += 1) {
+                cpuHandles[i] = commandBuffer->vertexStorageTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphics_pipeline->vertexStorageTextureCount,
+                graphicsPipeline->vertexStorageTextureCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                graphics_pipeline->rootSignature->vertexStorageTextureRootIndex,
+                commandBuffer->graphicsCommandList,
+                graphicsPipeline->rootSignature->vertexStorageTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        command_buffer->needVertexStorageTextureBind = false;
+        commandBuffer->needVertexStorageTextureBind = false;
     }
 
-    if (command_buffer->needVertexStorageBufferBind) {
-        if (graphics_pipeline->vertexStorageBufferCount > 0) {
-            for (Uint32 i = 0; i < graphics_pipeline->vertexStorageBufferCount; i += 1) {
-                cpuHandles[i] = command_buffer->vertexStorageBuffers[i]->srvDescriptor.cpuHandle;
+    if (commandBuffer->needVertexStorageBufferBind) {
+        if (graphicsPipeline->vertexStorageBufferCount > 0) {
+            for (Uint32 i = 0; i < graphicsPipeline->vertexStorageBufferCount; i += 1) {
+                cpuHandles[i] = commandBuffer->vertexStorageBuffers[i]->srvDescriptor.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphics_pipeline->vertexStorageBufferCount,
+                graphicsPipeline->vertexStorageBufferCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                graphics_pipeline->rootSignature->vertexStorageBufferRootIndex,
+                commandBuffer->graphicsCommandList,
+                graphicsPipeline->rootSignature->vertexStorageBufferRootIndex,
                 gpuDescriptorHandle);
         }
-        command_buffer->needVertexStorageBufferBind = false;
+        commandBuffer->needVertexStorageBufferBind = false;
     }
 
     for (Uint32 i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        if (command_buffer->needVertexUniformBufferBind[i]) {
-            if (graphics_pipeline->vertexUniformBufferCount > i) {
+        if (commandBuffer->needVertexUniformBufferBind[i]) {
+            if (graphicsPipeline->vertexUniformBufferCount > i) {
                 ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView(
-                    command_buffer->graphicsCommandList,
-                    graphics_pipeline->rootSignature->vertexUniformBufferRootIndex[i],
-                    command_buffer->vertexUniformBuffers[i]->buffer->virtualAddress + command_buffer->vertexUniformBuffers[i]->drawOffset);
+                    commandBuffer->graphicsCommandList,
+                    graphicsPipeline->rootSignature->vertexUniformBufferRootIndex[i],
+                    commandBuffer->vertexUniformBuffers[i]->buffer->virtualAddress + commandBuffer->vertexUniformBuffers[i]->drawOffset);
             }
-            command_buffer->needVertexUniformBufferBind[i] = false;
+            commandBuffer->needVertexUniformBufferBind[i] = false;
         }
     }
 
-    if (command_buffer->needFragmentSamplerBind) {
-        if (graphics_pipeline->fragmentSamplerCount > 0) {
-            for (Uint32 i = 0; i < graphics_pipeline->fragmentSamplerCount; i += 1) {
-                cpuHandles[i] = command_buffer->fragmentSamplers[i]->handle.cpuHandle;
+    if (commandBuffer->needFragmentSamplerBind) {
+        if (graphicsPipeline->fragmentSamplerCount > 0) {
+            for (Uint32 i = 0; i < graphicsPipeline->fragmentSamplerCount; i += 1) {
+                cpuHandles[i] = commandBuffer->fragmentSamplers[i]->handle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
                 cpuHandles,
-                graphics_pipeline->fragmentSamplerCount,
+                graphicsPipeline->fragmentSamplerCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                graphics_pipeline->rootSignature->fragmentSamplerRootIndex,
+                commandBuffer->graphicsCommandList,
+                graphicsPipeline->rootSignature->fragmentSamplerRootIndex,
                 gpuDescriptorHandle);
 
-            for (Uint32 i = 0; i < graphics_pipeline->fragmentSamplerCount; i += 1) {
-                cpuHandles[i] = command_buffer->fragmentSamplerTextures[i]->srvHandle.cpuHandle;
+            for (Uint32 i = 0; i < graphicsPipeline->fragmentSamplerCount; i += 1) {
+                cpuHandles[i] = commandBuffer->fragmentSamplerTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphics_pipeline->fragmentSamplerCount,
+                graphicsPipeline->fragmentSamplerCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                graphics_pipeline->rootSignature->fragmentSamplerTextureRootIndex,
+                commandBuffer->graphicsCommandList,
+                graphicsPipeline->rootSignature->fragmentSamplerTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        command_buffer->needFragmentSamplerBind = false;
+        commandBuffer->needFragmentSamplerBind = false;
     }
 
-    if (command_buffer->needFragmentStorageTextureBind) {
-        if (graphics_pipeline->fragmentStorageTextureCount > 0) {
-            for (Uint32 i = 0; i < graphics_pipeline->fragmentStorageTextureCount; i += 1) {
-                cpuHandles[i] = command_buffer->fragmentStorageTextures[i]->srvHandle.cpuHandle;
+    if (commandBuffer->needFragmentStorageTextureBind) {
+        if (graphicsPipeline->fragmentStorageTextureCount > 0) {
+            for (Uint32 i = 0; i < graphicsPipeline->fragmentStorageTextureCount; i += 1) {
+                cpuHandles[i] = commandBuffer->fragmentStorageTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphics_pipeline->fragmentStorageTextureCount,
+                graphicsPipeline->fragmentStorageTextureCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                graphics_pipeline->rootSignature->fragmentStorageTextureRootIndex,
+                commandBuffer->graphicsCommandList,
+                graphicsPipeline->rootSignature->fragmentStorageTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        command_buffer->needFragmentStorageTextureBind = false;
+        commandBuffer->needFragmentStorageTextureBind = false;
     }
 
-    if (command_buffer->needFragmentStorageBufferBind) {
-        if (graphics_pipeline->fragmentStorageBufferCount > 0) {
-            for (Uint32 i = 0; i < graphics_pipeline->fragmentStorageBufferCount; i += 1) {
-                cpuHandles[i] = command_buffer->fragmentStorageBuffers[i]->srvDescriptor.cpuHandle;
+    if (commandBuffer->needFragmentStorageBufferBind) {
+        if (graphicsPipeline->fragmentStorageBufferCount > 0) {
+            for (Uint32 i = 0; i < graphicsPipeline->fragmentStorageBufferCount; i += 1) {
+                cpuHandles[i] = commandBuffer->fragmentStorageBuffers[i]->srvDescriptor.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphics_pipeline->fragmentStorageBufferCount,
+                graphicsPipeline->fragmentStorageBufferCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                graphics_pipeline->rootSignature->fragmentStorageBufferRootIndex,
+                commandBuffer->graphicsCommandList,
+                graphicsPipeline->rootSignature->fragmentStorageBufferRootIndex,
                 gpuDescriptorHandle);
         }
-        command_buffer->needFragmentStorageBufferBind = false;
+        commandBuffer->needFragmentStorageBufferBind = false;
     }
 
     for (Uint32 i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        if (command_buffer->needFragmentUniformBufferBind[i]) {
-            if (graphics_pipeline->fragmentUniformBufferCount > i) {
+        if (commandBuffer->needFragmentUniformBufferBind[i]) {
+            if (graphicsPipeline->fragmentUniformBufferCount > i) {
                 ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView(
-                    command_buffer->graphicsCommandList,
-                    graphics_pipeline->rootSignature->fragmentUniformBufferRootIndex[i],
-                    command_buffer->fragmentUniformBuffers[i]->buffer->virtualAddress + command_buffer->fragmentUniformBuffers[i]->drawOffset);
+                    commandBuffer->graphicsCommandList,
+                    graphicsPipeline->rootSignature->fragmentUniformBufferRootIndex[i],
+                    commandBuffer->fragmentUniformBuffers[i]->buffer->virtualAddress + commandBuffer->fragmentUniformBuffers[i]->drawOffset);
             }
-            command_buffer->needFragmentUniformBufferBind[i] = false;
+            commandBuffer->needFragmentUniformBufferBind[i] = false;
         }
     }
 }
 
 static void D3D12_DrawIndexedPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_indices,
-    Uint32 num_instances,
-    Uint32 first_index,
-    Sint32 vertex_offset,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numIndices,
+    Uint32 numInstances,
+    Uint32 firstIndex,
+    Sint32 vertexOffset,
+    Uint32 firstInstance)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12_INTERNAL_BindGraphicsResources(d3d12CommandBuffer);
 
     ID3D12GraphicsCommandList_DrawIndexedInstanced(
         d3d12CommandBuffer->graphicsCommandList,
-        num_indices,
-        num_instances,
-        first_index,
-        vertex_offset,
-        first_instance);
+        numIndices,
+        numInstances,
+        firstIndex,
+        vertexOffset,
+        firstInstance);
 }
 
 static void D3D12_DrawPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_vertices,
-    Uint32 num_instances,
-    Uint32 first_vertex,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numVertices,
+    Uint32 numInstances,
+    Uint32 firstVertex,
+    Uint32 firstInstance)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12_INTERNAL_BindGraphicsResources(d3d12CommandBuffer);
 
     ID3D12GraphicsCommandList_DrawInstanced(
         d3d12CommandBuffer->graphicsCommandList,
-        num_vertices,
-        num_instances,
-        first_vertex,
-        first_instance);
+        numVertices,
+        numInstances,
+        firstVertex,
+        firstInstance);
 }
 
 static void D3D12_DrawPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Buffer *d3d12Buffer = ((D3D12BufferContainer *)buffer)->activeBuffer;
 
     D3D12_INTERNAL_BindGraphicsResources(d3d12CommandBuffer);
@@ -4667,7 +4667,7 @@ static void D3D12_DrawPrimitivesIndirect(
         ID3D12GraphicsCommandList_ExecuteIndirect(
             d3d12CommandBuffer->graphicsCommandList,
             d3d12CommandBuffer->renderer->indirectDrawCommandSignature,
-            draw_count,
+            drawCount,
             d3d12Buffer->handle,
             offset,
             NULL,
@@ -4677,7 +4677,7 @@ static void D3D12_DrawPrimitivesIndirect(
          * FIXME: we could make this real multi-draw
          * if we have a lookup to get command signature per pitch value
          */
-        for (Uint32 i = 0; i < draw_count; i += 1) {
+        for (Uint32 i = 0; i < drawCount; i += 1) {
             ID3D12GraphicsCommandList_ExecuteIndirect(
                 d3d12CommandBuffer->graphicsCommandList,
                 d3d12CommandBuffer->renderer->indirectDrawCommandSignature,
@@ -4691,13 +4691,13 @@ static void D3D12_DrawPrimitivesIndirect(
 }
 
 static void D3D12_DrawIndexedPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Buffer *d3d12Buffer = ((D3D12BufferContainer *)buffer)->activeBuffer;
 
     D3D12_INTERNAL_BindGraphicsResources(d3d12CommandBuffer);
@@ -4707,7 +4707,7 @@ static void D3D12_DrawIndexedPrimitivesIndirect(
         ID3D12GraphicsCommandList_ExecuteIndirect(
             d3d12CommandBuffer->graphicsCommandList,
             d3d12CommandBuffer->renderer->indirectIndexedDrawCommandSignature,
-            draw_count,
+            drawCount,
             d3d12Buffer->handle,
             offset,
             NULL,
@@ -4717,7 +4717,7 @@ static void D3D12_DrawIndexedPrimitivesIndirect(
          * FIXME: we could make this real multi-draw
          * if we have a lookup to get command signature per pitch value
          */
-        for (Uint32 i = 0; i < draw_count; i += 1) {
+        for (Uint32 i = 0; i < drawCount; i += 1) {
             ID3D12GraphicsCommandList_ExecuteIndirect(
                 d3d12CommandBuffer->graphicsCommandList,
                 d3d12CommandBuffer->renderer->indirectIndexedDrawCommandSignature,
@@ -4731,9 +4731,9 @@ static void D3D12_DrawIndexedPrimitivesIndirect(
 }
 
 static void D3D12_EndRenderPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     Uint32 i;
 
     for (i = 0; i < d3d12CommandBuffer->colorAttachmentTextureSubresourceCount; i += 1) {
@@ -4786,24 +4786,24 @@ static void D3D12_EndRenderPass(
 // Compute Pass
 
 static void D3D12_BeginComputePass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
-    Uint32 num_storage_texture_bindings,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
-    Uint32 num_storage_buffer_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
+    Uint32 numStorageTextureBindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
+    Uint32 numStorageBufferBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresourceCount = num_storage_texture_bindings;
-    d3d12CommandBuffer->computeWriteOnlyStorageBufferCount = num_storage_buffer_bindings;
+    d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresourceCount = numStorageTextureBindings;
+    d3d12CommandBuffer->computeWriteOnlyStorageBufferCount = numStorageBufferBindings;
 
     /* Write-only resources will be actually bound in BindComputePipeline
      * after the root signature is set.
      * We also have to scan to see which barriers we actually need because depth slices aren't separate subresources
      */
-    if (num_storage_texture_bindings > 0) {
-        for (Uint32 i = 0; i < num_storage_texture_bindings; i += 1) {
-            D3D12TextureContainer *container = (D3D12TextureContainer *)storage_texture_bindings[i].texture;
+    if (numStorageTextureBindings > 0) {
+        for (Uint32 i = 0; i < numStorageTextureBindings; i += 1) {
+            D3D12TextureContainer *container = (D3D12TextureContainer *)storageTextureBindings[i].texture;
             if (!(container->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
                 SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
             }
@@ -4811,9 +4811,9 @@ static void D3D12_BeginComputePass(
             D3D12TextureSubresource *subresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
                 d3d12CommandBuffer,
                 container,
-                storage_texture_bindings[i].layer,
-                storage_texture_bindings[i].mip_level,
-                storage_texture_bindings[i].cycle,
+                storageTextureBindings[i].layer,
+                storageTextureBindings[i].mip_level,
+                storageTextureBindings[i].cycle,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
             d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresources[i] = subresource;
@@ -4824,16 +4824,16 @@ static void D3D12_BeginComputePass(
         }
     }
 
-    if (num_storage_buffer_bindings > 0) {
-        for (Uint32 i = 0; i < num_storage_buffer_bindings; i += 1) {
-            D3D12BufferContainer *container = (D3D12BufferContainer *)storage_buffer_bindings[i].buffer;
+    if (numStorageBufferBindings > 0) {
+        for (Uint32 i = 0; i < numStorageBufferBindings; i += 1) {
+            D3D12BufferContainer *container = (D3D12BufferContainer *)storageBufferBindings[i].buffer;
             if (!(container->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
                 SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
             }
             D3D12Buffer *buffer = D3D12_INTERNAL_PrepareBufferForWrite(
                 d3d12CommandBuffer,
                 container,
-                storage_buffer_bindings[i].cycle,
+                storageBufferBindings[i].cycle,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
             d3d12CommandBuffer->computeWriteOnlyStorageBuffers[i] = buffer;
@@ -4846,11 +4846,11 @@ static void D3D12_BeginComputePass(
 }
 
 static void D3D12_BindComputePipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUComputePipeline *computePipeline)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
-    D3D12ComputePipeline *pipeline = (D3D12ComputePipeline *)compute_pipeline;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12ComputePipeline *pipeline = (D3D12ComputePipeline *)computePipeline;
     D3D12_CPU_DESCRIPTOR_HANDLE cpuHandles[MAX_TEXTURE_SAMPLERS_PER_STAGE];
     D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
 
@@ -4871,7 +4871,7 @@ static void D3D12_BindComputePipeline(
         d3d12CommandBuffer->needComputeUniformBufferBind[i] = true;
     }
 
-    for (Uint32 i = 0; i < pipeline->num_uniform_buffers; i += 1) {
+    for (Uint32 i = 0; i < pipeline->numUniformBuffers; i += 1) {
         if (d3d12CommandBuffer->computeUniformBuffers[i] == NULL) {
             d3d12CommandBuffer->computeUniformBuffers[i] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
                 d3d12CommandBuffer);
@@ -4919,23 +4919,23 @@ static void D3D12_BindComputePipeline(
 }
 
 static void D3D12_BindComputeStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        if (d3d12CommandBuffer->computeReadOnlyStorageTextures[first_slot + i] != NULL) {
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        if (d3d12CommandBuffer->computeReadOnlyStorageTextures[firstSlot + i] != NULL) {
             D3D12_INTERNAL_TextureTransitionToDefaultUsage(
                 d3d12CommandBuffer,
                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                d3d12CommandBuffer->computeReadOnlyStorageTextures[first_slot + i]);
+                d3d12CommandBuffer->computeReadOnlyStorageTextures[firstSlot + i]);
         }
 
-        D3D12TextureContainer *container = (D3D12TextureContainer *)storage_textures[i];
-        d3d12CommandBuffer->computeReadOnlyStorageTextures[first_slot + i] = container->activeTexture;
+        D3D12TextureContainer *container = (D3D12TextureContainer *)storageTextures[i];
+        d3d12CommandBuffer->computeReadOnlyStorageTextures[firstSlot + i] = container->activeTexture;
 
         D3D12_INTERNAL_TextureTransitionFromDefaultUsage(
             d3d12CommandBuffer,
@@ -4951,25 +4951,25 @@ static void D3D12_BindComputeStorageTextures(
 }
 
 static void D3D12_BindComputeStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        if (d3d12CommandBuffer->computeReadOnlyStorageBuffers[first_slot + i] != NULL) {
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        if (d3d12CommandBuffer->computeReadOnlyStorageBuffers[firstSlot + i] != NULL) {
             D3D12_INTERNAL_BufferTransitionToDefaultUsage(
                 d3d12CommandBuffer,
                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                d3d12CommandBuffer->computeReadOnlyStorageBuffers[first_slot + i]);
+                d3d12CommandBuffer->computeReadOnlyStorageBuffers[firstSlot + i]);
         }
 
-        D3D12BufferContainer *container = (D3D12BufferContainer *)storage_buffers[i];
+        D3D12BufferContainer *container = (D3D12BufferContainer *)storageBuffers[i];
         D3D12Buffer *buffer = container->activeBuffer;
 
-        d3d12CommandBuffer->computeReadOnlyStorageBuffers[first_slot + i] = buffer;
+        d3d12CommandBuffer->computeReadOnlyStorageBuffers[firstSlot + i] = buffer;
 
         D3D12_INTERNAL_BufferTransitionFromDefaultUsage(
             d3d12CommandBuffer,
@@ -4985,106 +4985,106 @@ static void D3D12_BindComputeStorageBuffers(
 }
 
 static void D3D12_PushComputeUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
     D3D12_INTERNAL_PushUniformData(
         d3d12CommandBuffer,
         SDL_GPU_SHADERSTAGE_COMPUTE,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void D3D12_INTERNAL_BindComputeResources(
-    D3D12CommandBuffer *command_buffer)
+    D3D12CommandBuffer *commandBuffer)
 {
-    D3D12ComputePipeline *compute_pipeline = command_buffer->currentComputePipeline;
+    D3D12ComputePipeline *computePipeline = commandBuffer->currentComputePipeline;
 
     D3D12_CPU_DESCRIPTOR_HANDLE cpuHandles[MAX_TEXTURE_SAMPLERS_PER_STAGE];
     D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
 
-    if (command_buffer->needComputeReadOnlyStorageTextureBind) {
-        if (compute_pipeline->num_readonly_storage_textures > 0) {
-            for (Uint32 i = 0; i < compute_pipeline->num_readonly_storage_textures; i += 1) {
-                cpuHandles[i] = command_buffer->computeReadOnlyStorageTextures[i]->srvHandle.cpuHandle;
+    if (commandBuffer->needComputeReadOnlyStorageTextureBind) {
+        if (computePipeline->num_readonly_storage_textures > 0) {
+            for (Uint32 i = 0; i < computePipeline->num_readonly_storage_textures; i += 1) {
+                cpuHandles[i] = commandBuffer->computeReadOnlyStorageTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                compute_pipeline->num_readonly_storage_textures,
+                computePipeline->num_readonly_storage_textures,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetComputeRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                compute_pipeline->rootSignature->readOnlyStorageTextureRootIndex,
+                commandBuffer->graphicsCommandList,
+                computePipeline->rootSignature->readOnlyStorageTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        command_buffer->needComputeReadOnlyStorageTextureBind = false;
+        commandBuffer->needComputeReadOnlyStorageTextureBind = false;
     }
 
-    if (command_buffer->needComputeReadOnlyStorageBufferBind) {
-        if (compute_pipeline->num_readonly_storage_buffers > 0) {
-            for (Uint32 i = 0; i < compute_pipeline->num_readonly_storage_buffers; i += 1) {
-                cpuHandles[i] = command_buffer->computeReadOnlyStorageBuffers[i]->srvDescriptor.cpuHandle;
+    if (commandBuffer->needComputeReadOnlyStorageBufferBind) {
+        if (computePipeline->num_readonly_storage_buffers > 0) {
+            for (Uint32 i = 0; i < computePipeline->num_readonly_storage_buffers; i += 1) {
+                cpuHandles[i] = commandBuffer->computeReadOnlyStorageBuffers[i]->srvDescriptor.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                command_buffer,
+                commandBuffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                compute_pipeline->num_readonly_storage_buffers,
+                computePipeline->num_readonly_storage_buffers,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetComputeRootDescriptorTable(
-                command_buffer->graphicsCommandList,
-                compute_pipeline->rootSignature->readOnlyStorageBufferRootIndex,
+                commandBuffer->graphicsCommandList,
+                computePipeline->rootSignature->readOnlyStorageBufferRootIndex,
                 gpuDescriptorHandle);
         }
-        command_buffer->needComputeReadOnlyStorageBufferBind = false;
+        commandBuffer->needComputeReadOnlyStorageBufferBind = false;
     }
 
     for (Uint32 i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        if (command_buffer->needComputeUniformBufferBind[i]) {
-            if (compute_pipeline->num_uniform_buffers > i) {
+        if (commandBuffer->needComputeUniformBufferBind[i]) {
+            if (computePipeline->numUniformBuffers > i) {
                 ID3D12GraphicsCommandList_SetComputeRootConstantBufferView(
-                    command_buffer->graphicsCommandList,
-                    compute_pipeline->rootSignature->uniformBufferRootIndex[i],
-                    command_buffer->computeUniformBuffers[i]->buffer->virtualAddress + command_buffer->computeUniformBuffers[i]->drawOffset);
+                    commandBuffer->graphicsCommandList,
+                    computePipeline->rootSignature->uniformBufferRootIndex[i],
+                    commandBuffer->computeUniformBuffers[i]->buffer->virtualAddress + commandBuffer->computeUniformBuffers[i]->drawOffset);
             }
         }
-        command_buffer->needComputeUniformBufferBind[i] = false;
+        commandBuffer->needComputeUniformBufferBind[i] = false;
     }
 }
 
 static void D3D12_DispatchCompute(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 groupcount_x,
-    Uint32 groupcount_y,
-    Uint32 groupcount_z)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 groupcountX,
+    Uint32 groupcountY,
+    Uint32 groupcountZ)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
     D3D12_INTERNAL_BindComputeResources(d3d12CommandBuffer);
     ID3D12GraphicsCommandList_Dispatch(
         d3d12CommandBuffer->graphicsCommandList,
-        groupcount_x,
-        groupcount_y,
-        groupcount_z);
+        groupcountX,
+        groupcountY,
+        groupcountZ);
 }
 
 static void D3D12_DispatchComputeIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Buffer *d3d12Buffer = ((D3D12BufferContainer *)buffer)->activeBuffer;
 
     D3D12_INTERNAL_BindComputeResources(d3d12CommandBuffer);
@@ -5099,9 +5099,9 @@ static void D3D12_DispatchComputeIndirect(
 }
 
 static void D3D12_EndComputePass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
 
     for (Uint32 i = 0; i < d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresourceCount; i += 1) {
         if (d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresources[i]) {
@@ -5156,11 +5156,11 @@ static void D3D12_EndComputePass(
 
 static void *D3D12_MapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer,
+    SDL_GPUTransferBuffer *transferBuffer,
     bool cycle)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12BufferContainer *container = (D3D12BufferContainer *)transfer_buffer;
+    D3D12BufferContainer *container = (D3D12BufferContainer *)transferBuffer;
     void *dataPointer;
 
     if (
@@ -5187,10 +5187,10 @@ static void *D3D12_MapTransferBuffer(
 
 static void D3D12_UnmapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     (void)driverData;
-    D3D12BufferContainer *container = (D3D12BufferContainer *)transfer_buffer;
+    D3D12BufferContainer *container = (D3D12BufferContainer *)transferBuffer;
 
     // Upload buffers are persistently mapped, download buffers are not
     if (container->type == D3D12_BUFFER_TYPE_DOWNLOAD) {
@@ -5204,19 +5204,19 @@ static void D3D12_UnmapTransferBuffer(
 // Copy Pass
 
 static void D3D12_BeginCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     // no-op
-    (void)command_buffer;
+    (void)commandBuffer;
 }
 
 static void D3D12_UploadToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)source->transfer_buffer;
     D3D12Buffer *temporaryBuffer = NULL;
     D3D12_TEXTURE_COPY_LOCATION sourceLocation;
@@ -5387,12 +5387,12 @@ static void D3D12_UploadToTexture(
 }
 
 static void D3D12_UploadToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)source->transfer_buffer;
     D3D12BufferContainer *bufferContainer = (D3D12BufferContainer *)destination->buffer;
 
@@ -5422,7 +5422,7 @@ static void D3D12_UploadToBuffer(
 }
 
 static void D3D12_CopyTextureToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -5430,7 +5430,7 @@ static void D3D12_CopyTextureToTexture(
     Uint32 d,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12_TEXTURE_COPY_LOCATION sourceLocation;
     D3D12_TEXTURE_COPY_LOCATION destinationLocation;
 
@@ -5491,13 +5491,13 @@ static void D3D12_CopyTextureToTexture(
 }
 
 static void D3D12_CopyBufferToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12BufferContainer *sourceContainer = (D3D12BufferContainer *)source->buffer;
     D3D12BufferContainer *destinationContainer = (D3D12BufferContainer *)destination->buffer;
 
@@ -5536,11 +5536,11 @@ static void D3D12_CopyBufferToBuffer(
 }
 
 static void D3D12_DownloadFromTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12_TEXTURE_COPY_LOCATION sourceLocation;
     D3D12_TEXTURE_COPY_LOCATION destinationLocation;
     Uint32 pixelsPerRow = destination->pixels_per_row;
@@ -5675,11 +5675,11 @@ static void D3D12_DownloadFromTexture(
 }
 
 static void D3D12_DownloadFromBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12BufferContainer *sourceContainer = (D3D12BufferContainer *)source->buffer;
     D3D12BufferContainer *destinationContainer = (D3D12BufferContainer *)destination->transfer_buffer;
 
@@ -5709,17 +5709,17 @@ static void D3D12_DownloadFromBuffer(
 }
 
 static void D3D12_EndCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     // no-op
-    (void)command_buffer;
+    (void)commandBuffer;
 }
 
 static void D3D12_GenerateMipmaps(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUTexture *texture)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Renderer *renderer = d3d12CommandBuffer->renderer;
     D3D12TextureContainer *container = (D3D12TextureContainer *)texture;
     SDL_GPUGraphicsPipeline *blitPipeline;
@@ -5764,7 +5764,7 @@ static void D3D12_GenerateMipmaps(
             dstRegion.h = container->header.info.height >> levelIndex;
 
             SDL_BlitGPUTexture(
-                command_buffer,
+                commandBuffer,
                 &srcRegion,
                 &dstRegion,
                 SDL_FLIP_NONE,
@@ -5777,21 +5777,21 @@ static void D3D12_GenerateMipmaps(
 }
 
 static void D3D12_Blit(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flip_mode,
+    SDL_FlipMode flipMode,
     SDL_GPUFilter filter,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Renderer *renderer = (D3D12Renderer *)d3d12CommandBuffer->renderer;
 
     SDL_GPU_BlitCommon(
-        command_buffer,
+        commandBuffer,
         source,
         destination,
-        flip_mode,
+        flipMode,
         filter,
         cycle,
         renderer->blitLinearSampler,
@@ -5818,7 +5818,7 @@ static D3D12WindowData *D3D12_INTERNAL_FetchWindowData(
 static bool D3D12_SupportsSwapchainComposition(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition)
+    SDL_GPUSwapchainComposition swapchainComposition)
 {
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
     // FIXME: HDR support would be nice to add, but it seems complicated...
@@ -5831,7 +5831,7 @@ static bool D3D12_SupportsSwapchainComposition(
     Uint32 colorSpaceSupport;
     HRESULT res;
 
-    format = SwapchainCompositionToTextureFormat[swapchain_composition];
+    format = SwapchainCompositionToTextureFormat[swapchainComposition];
 
     formatSupport.Format = format;
     res = ID3D12Device_CheckFeatureSupport(
@@ -5855,10 +5855,10 @@ static bool D3D12_SupportsSwapchainComposition(
     }
 
     // Check the color space support if necessary
-    if (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
+    if (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
         IDXGISwapChain3_CheckColorSpaceSupport(
             windowData->swapchain,
-            SwapchainCompositionToColorSpace[swapchain_composition],
+            SwapchainCompositionToColorSpace[swapchainComposition],
             &colorSpaceSupport);
 
         if (!(colorSpaceSupport & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT)) {
@@ -5873,12 +5873,12 @@ static bool D3D12_SupportsSwapchainComposition(
 static bool D3D12_SupportsPresentMode(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUPresentMode presentMode)
 {
     (void)driverData;
     (void)window;
 
-    switch (present_mode) {
+    switch (presentMode) {
     case SDL_GPU_PRESENTMODE_IMMEDIATE:
     case SDL_GPU_PRESENTMODE_VSYNC:
         return true;
@@ -6159,7 +6159,7 @@ static bool D3D12_INTERNAL_ResizeSwapchainIfNeeded(
             if (!D3D12_INTERNAL_InitializeSwapchainTexture(
                     renderer,
                     windowData->swapchain,
-                    windowData->swapchain_composition,
+                    windowData->swapchainComposition,
                     i,
                     &windowData->textureContainers[i])) {
                 return false;
@@ -6196,8 +6196,8 @@ static void D3D12_INTERNAL_DestroySwapchain(
 static bool D3D12_INTERNAL_CreateSwapchain(
     D3D12Renderer *renderer,
     D3D12WindowData *windowData,
-    SDL_GPUSwapchainComposition swapchain_composition,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUSwapchainComposition swapchainComposition,
+    SDL_GPUPresentMode presentMode)
 {
     HWND dxgiHandle;
     int width, height;
@@ -6219,7 +6219,7 @@ static bool D3D12_INTERNAL_CreateSwapchain(
     // Get the window size
     SDL_GetWindowSize(windowData->window, &width, &height);
 
-    swapchainFormat = SwapchainCompositionToTextureFormat[swapchain_composition];
+    swapchainFormat = SwapchainCompositionToTextureFormat[swapchainComposition];
 
     // Initialize the swapchain buffer descriptor
     swapchainDesc.Width = 0;
@@ -6272,11 +6272,11 @@ static bool D3D12_INTERNAL_CreateSwapchain(
     IDXGISwapChain1_Release(swapchain);
     ERROR_CHECK_RETURN("Could not create IDXGISwapChain3", 0);
 
-    if (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
+    if (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
         // Support already verified if we hit this block
         IDXGISwapChain3_SetColorSpace1(
             swapchain3,
-            SwapchainCompositionToColorSpace[swapchain_composition]);
+            SwapchainCompositionToColorSpace[swapchainComposition]);
     }
 
     /*
@@ -6314,9 +6314,9 @@ static bool D3D12_INTERNAL_CreateSwapchain(
 
     // Initialize the swapchain data
     windowData->swapchain = swapchain3;
-    windowData->present_mode = present_mode;
-    windowData->swapchain_composition = swapchain_composition;
-    windowData->swapchainColorSpace = SwapchainCompositionToColorSpace[swapchain_composition];
+    windowData->present_mode = presentMode;
+    windowData->swapchainComposition = swapchainComposition;
+    windowData->swapchainColorSpace = SwapchainCompositionToColorSpace[swapchainComposition];
     windowData->frameCounter = 0;
 
     // Precache blit pipelines for the swapchain format
@@ -6324,7 +6324,7 @@ static bool D3D12_INTERNAL_CreateSwapchain(
         SDL_GPU_FetchBlitPipeline(
             renderer->sdlGPUDevice,
             (SDL_GPUTextureType)i,
-            SwapchainCompositionToSDLTextureFormat[swapchain_composition],
+            SwapchainCompositionToSDLTextureFormat[swapchainComposition],
             renderer->blitVertexShader,
             renderer->blitFrom2DShader,
             renderer->blitFrom2DArrayShader,
@@ -6342,7 +6342,7 @@ static bool D3D12_INTERNAL_CreateSwapchain(
         if (!D3D12_INTERNAL_InitializeSwapchainTexture(
                 renderer,
                 swapchain3,
-                swapchain_composition,
+                swapchainComposition,
                 i,
                 &windowData->textureContainers[i])) {
             IDXGISwapChain3_Release(swapchain3);
@@ -6438,8 +6438,8 @@ static void D3D12_ReleaseWindow(
 static bool D3D12_SetSwapchainParameters(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUSwapchainComposition swapchainComposition,
+    SDL_GPUPresentMode presentMode)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     D3D12WindowData *windowData = D3D12_INTERNAL_FetchWindowData(window);
@@ -6449,19 +6449,19 @@ static bool D3D12_SetSwapchainParameters(
         return false;
     }
 
-    if (!D3D12_SupportsSwapchainComposition(driverData, window, swapchain_composition)) {
+    if (!D3D12_SupportsSwapchainComposition(driverData, window, swapchainComposition)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Swapchain composition not supported!");
         return false;
     }
 
-    if (!D3D12_SupportsPresentMode(driverData, window, present_mode)) {
+    if (!D3D12_SupportsPresentMode(driverData, window, presentMode)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Present mode not supported!");
         return false;
     }
 
     if (
-        swapchain_composition != windowData->swapchain_composition ||
-        present_mode != windowData->present_mode) {
+        swapchainComposition != windowData->swapchainComposition ||
+        presentMode != windowData->present_mode) {
         D3D12_Wait(driverData);
 
         // Recreate the swapchain
@@ -6472,8 +6472,8 @@ static bool D3D12_SetSwapchainParameters(
         return D3D12_INTERNAL_CreateSwapchain(
             renderer,
             windowData,
-            swapchain_composition,
-            present_mode);
+            swapchainComposition,
+            presentMode);
     }
 
     return true;
@@ -6539,13 +6539,13 @@ static D3D12Fence *D3D12_INTERNAL_AcquireFence(
 static void D3D12_INTERNAL_AllocateCommandBuffer(
     D3D12Renderer *renderer)
 {
-    D3D12CommandBuffer *command_buffer;
+    D3D12CommandBuffer *commandBuffer;
     HRESULT res;
     ID3D12CommandAllocator *commandAllocator;
     ID3D12GraphicsCommandList *commandList;
 
-    command_buffer = (D3D12CommandBuffer *)SDL_calloc(1, sizeof(D3D12CommandBuffer));
-    if (!command_buffer) {
+    commandBuffer = (D3D12CommandBuffer *)SDL_calloc(1, sizeof(D3D12CommandBuffer));
+    if (!commandBuffer) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandList. Out of Memory");
         return;
     }
@@ -6557,10 +6557,10 @@ static void D3D12_INTERNAL_AllocateCommandBuffer(
         (void **)&commandAllocator);
     if (FAILED(res)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandAllocator");
-        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
         return;
     }
-    command_buffer->commandAllocator = commandAllocator;
+    commandBuffer->commandAllocator = commandAllocator;
 
     res = ID3D12Device_CreateCommandList(
         renderer->device,
@@ -6573,67 +6573,67 @@ static void D3D12_INTERNAL_AllocateCommandBuffer(
 
     if (FAILED(res)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandList");
-        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
         return;
     }
-    command_buffer->graphicsCommandList = commandList;
+    commandBuffer->graphicsCommandList = commandList;
 
-    command_buffer->renderer = renderer;
-    command_buffer->inFlightFence = NULL;
+    commandBuffer->renderer = renderer;
+    commandBuffer->inFlightFence = NULL;
 
     // Window handling
-    command_buffer->presentDataCapacity = 1;
-    command_buffer->presentDataCount = 0;
-    command_buffer->presentDatas = (D3D12PresentData *)SDL_calloc(
-        command_buffer->presentDataCapacity, sizeof(D3D12PresentData));
+    commandBuffer->presentDataCapacity = 1;
+    commandBuffer->presentDataCount = 0;
+    commandBuffer->presentDatas = (D3D12PresentData *)SDL_calloc(
+        commandBuffer->presentDataCapacity, sizeof(D3D12PresentData));
 
     // Resource tracking
-    command_buffer->usedTextureCapacity = 4;
-    command_buffer->usedTextureCount = 0;
-    command_buffer->usedTextures = (D3D12Texture **)SDL_calloc(
-        command_buffer->usedTextureCapacity, sizeof(D3D12Texture *));
+    commandBuffer->usedTextureCapacity = 4;
+    commandBuffer->usedTextureCount = 0;
+    commandBuffer->usedTextures = (D3D12Texture **)SDL_calloc(
+        commandBuffer->usedTextureCapacity, sizeof(D3D12Texture *));
 
-    command_buffer->usedBufferCapacity = 4;
-    command_buffer->usedBufferCount = 0;
-    command_buffer->usedBuffers = (D3D12Buffer **)SDL_calloc(
-        command_buffer->usedBufferCapacity, sizeof(D3D12Buffer *));
+    commandBuffer->usedBufferCapacity = 4;
+    commandBuffer->usedBufferCount = 0;
+    commandBuffer->usedBuffers = (D3D12Buffer **)SDL_calloc(
+        commandBuffer->usedBufferCapacity, sizeof(D3D12Buffer *));
 
-    command_buffer->usedSamplerCapacity = 4;
-    command_buffer->usedSamplerCount = 0;
-    command_buffer->usedSamplers = (D3D12Sampler **)SDL_calloc(
-        command_buffer->usedSamplerCapacity, sizeof(D3D12Sampler *));
+    commandBuffer->usedSamplerCapacity = 4;
+    commandBuffer->usedSamplerCount = 0;
+    commandBuffer->usedSamplers = (D3D12Sampler **)SDL_calloc(
+        commandBuffer->usedSamplerCapacity, sizeof(D3D12Sampler *));
 
-    command_buffer->usedGraphicsPipelineCapacity = 4;
-    command_buffer->usedGraphicsPipelineCount = 0;
-    command_buffer->usedGraphicsPipelines = (D3D12GraphicsPipeline **)SDL_calloc(
-        command_buffer->usedGraphicsPipelineCapacity, sizeof(D3D12GraphicsPipeline *));
+    commandBuffer->usedGraphicsPipelineCapacity = 4;
+    commandBuffer->usedGraphicsPipelineCount = 0;
+    commandBuffer->usedGraphicsPipelines = (D3D12GraphicsPipeline **)SDL_calloc(
+        commandBuffer->usedGraphicsPipelineCapacity, sizeof(D3D12GraphicsPipeline *));
 
-    command_buffer->usedComputePipelineCapacity = 4;
-    command_buffer->usedComputePipelineCount = 0;
-    command_buffer->usedComputePipelines = (D3D12ComputePipeline **)SDL_calloc(
-        command_buffer->usedComputePipelineCapacity, sizeof(D3D12ComputePipeline *));
+    commandBuffer->usedComputePipelineCapacity = 4;
+    commandBuffer->usedComputePipelineCount = 0;
+    commandBuffer->usedComputePipelines = (D3D12ComputePipeline **)SDL_calloc(
+        commandBuffer->usedComputePipelineCapacity, sizeof(D3D12ComputePipeline *));
 
-    command_buffer->usedUniformBufferCapacity = 4;
-    command_buffer->usedUniformBufferCount = 0;
-    command_buffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_calloc(
-        command_buffer->usedUniformBufferCapacity, sizeof(D3D12UniformBuffer *));
+    commandBuffer->usedUniformBufferCapacity = 4;
+    commandBuffer->usedUniformBufferCount = 0;
+    commandBuffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_calloc(
+        commandBuffer->usedUniformBufferCapacity, sizeof(D3D12UniformBuffer *));
 
-    command_buffer->textureDownloadCapacity = 4;
-    command_buffer->textureDownloadCount = 0;
-    command_buffer->textureDownloads = (D3D12TextureDownload **)SDL_calloc(
-        command_buffer->textureDownloadCapacity, sizeof(D3D12TextureDownload *));
+    commandBuffer->textureDownloadCapacity = 4;
+    commandBuffer->textureDownloadCount = 0;
+    commandBuffer->textureDownloads = (D3D12TextureDownload **)SDL_calloc(
+        commandBuffer->textureDownloadCapacity, sizeof(D3D12TextureDownload *));
 
     if (
-        (!command_buffer->presentDatas) ||
-        (!command_buffer->usedTextures) ||
-        (!command_buffer->usedBuffers) ||
-        (!command_buffer->usedSamplers) ||
-        (!command_buffer->usedGraphicsPipelines) ||
-        (!command_buffer->usedComputePipelines) ||
-        (!command_buffer->usedUniformBuffers) ||
-        (!command_buffer->textureDownloads)) {
+        (!commandBuffer->presentDatas) ||
+        (!commandBuffer->usedTextures) ||
+        (!commandBuffer->usedBuffers) ||
+        (!commandBuffer->usedSamplers) ||
+        (!commandBuffer->usedGraphicsPipelines) ||
+        (!commandBuffer->usedComputePipelines) ||
+        (!commandBuffer->usedUniformBuffers) ||
+        (!commandBuffer->textureDownloads)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandList. Out of Memory");
-        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
         return;
     }
 
@@ -6643,117 +6643,117 @@ static void D3D12_INTERNAL_AllocateCommandBuffer(
 
     if (!resizedAvailableCommandBuffers) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandList. Out of Memory");
-        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
         return;
     }
     // Add to inactive command buffer array
     renderer->availableCommandBufferCapacity += 1;
     renderer->availableCommandBuffers = resizedAvailableCommandBuffers;
 
-    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
+    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
     renderer->availableCommandBufferCount += 1;
 }
 
 static D3D12CommandBuffer *D3D12_INTERNAL_AcquireCommandBufferFromPool(
     D3D12Renderer *renderer)
 {
-    D3D12CommandBuffer *command_buffer;
+    D3D12CommandBuffer *commandBuffer;
 
     if (renderer->availableCommandBufferCount == 0) {
         D3D12_INTERNAL_AllocateCommandBuffer(renderer);
     }
 
-    command_buffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
+    commandBuffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
     renderer->availableCommandBufferCount -= 1;
 
-    return command_buffer;
+    return commandBuffer;
 }
 
 static SDL_GPUCommandBuffer *D3D12_AcquireCommandBuffer(
     SDL_GPURenderer *driverData)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12CommandBuffer *command_buffer;
+    D3D12CommandBuffer *commandBuffer;
     ID3D12DescriptorHeap *heaps[2];
     SDL_zeroa(heaps);
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
-    command_buffer = D3D12_INTERNAL_AcquireCommandBufferFromPool(renderer);
+    commandBuffer = D3D12_INTERNAL_AcquireCommandBufferFromPool(renderer);
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
-    if (command_buffer == NULL) {
+    if (commandBuffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire command buffer!");
         return NULL;
     }
 
     // Set the descriptor heaps!
-    command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV] =
-        D3D12_INTERNAL_AcquireDescriptorHeapFromPool(command_buffer, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV] =
+        D3D12_INTERNAL_AcquireDescriptorHeapFromPool(commandBuffer, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    if (!command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]) {
+    if (!commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire descriptor heap!");
-        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
         return NULL;
     }
 
-    command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER] =
-        D3D12_INTERNAL_AcquireDescriptorHeapFromPool(command_buffer, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+    commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER] =
+        D3D12_INTERNAL_AcquireDescriptorHeapFromPool(commandBuffer, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
-    if (!command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]) {
+    if (!commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire descriptor heap!");
-        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
         return NULL;
     }
 
-    heaps[0] = command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]->handle;
-    heaps[1] = command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]->handle;
+    heaps[0] = commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]->handle;
+    heaps[1] = commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]->handle;
 
     ID3D12GraphicsCommandList_SetDescriptorHeaps(
-        command_buffer->graphicsCommandList,
+        commandBuffer->graphicsCommandList,
         2,
         heaps);
 
     // Set the bind state
-    command_buffer->currentGraphicsPipeline = NULL;
+    commandBuffer->currentGraphicsPipeline = NULL;
 
-    SDL_zeroa(command_buffer->colorAttachmentTextureSubresources);
-    command_buffer->colorAttachmentTextureSubresourceCount = 0;
-    command_buffer->depthStencilTextureSubresource = NULL;
+    SDL_zeroa(commandBuffer->colorAttachmentTextureSubresources);
+    commandBuffer->colorAttachmentTextureSubresourceCount = 0;
+    commandBuffer->depthStencilTextureSubresource = NULL;
 
-    SDL_zeroa(command_buffer->vertexBuffers);
-    SDL_zeroa(command_buffer->vertexBufferOffsets);
-    command_buffer->vertexBufferCount = 0;
+    SDL_zeroa(commandBuffer->vertexBuffers);
+    SDL_zeroa(commandBuffer->vertexBufferOffsets);
+    commandBuffer->vertexBufferCount = 0;
 
-    SDL_zeroa(command_buffer->vertexSamplerTextures);
-    SDL_zeroa(command_buffer->vertexSamplers);
-    SDL_zeroa(command_buffer->vertexStorageTextures);
-    SDL_zeroa(command_buffer->vertexStorageBuffers);
-    SDL_zeroa(command_buffer->vertexUniformBuffers);
+    SDL_zeroa(commandBuffer->vertexSamplerTextures);
+    SDL_zeroa(commandBuffer->vertexSamplers);
+    SDL_zeroa(commandBuffer->vertexStorageTextures);
+    SDL_zeroa(commandBuffer->vertexStorageBuffers);
+    SDL_zeroa(commandBuffer->vertexUniformBuffers);
 
-    SDL_zeroa(command_buffer->fragmentSamplerTextures);
-    SDL_zeroa(command_buffer->fragmentSamplers);
-    SDL_zeroa(command_buffer->fragmentStorageTextures);
-    SDL_zeroa(command_buffer->fragmentStorageBuffers);
-    SDL_zeroa(command_buffer->fragmentUniformBuffers);
+    SDL_zeroa(commandBuffer->fragmentSamplerTextures);
+    SDL_zeroa(commandBuffer->fragmentSamplers);
+    SDL_zeroa(commandBuffer->fragmentStorageTextures);
+    SDL_zeroa(commandBuffer->fragmentStorageBuffers);
+    SDL_zeroa(commandBuffer->fragmentUniformBuffers);
 
-    SDL_zeroa(command_buffer->computeReadOnlyStorageTextures);
-    SDL_zeroa(command_buffer->computeReadOnlyStorageBuffers);
-    SDL_zeroa(command_buffer->computeWriteOnlyStorageTextureSubresources);
-    SDL_zeroa(command_buffer->computeWriteOnlyStorageBuffers);
-    SDL_zeroa(command_buffer->computeUniformBuffers);
+    SDL_zeroa(commandBuffer->computeReadOnlyStorageTextures);
+    SDL_zeroa(commandBuffer->computeReadOnlyStorageBuffers);
+    SDL_zeroa(commandBuffer->computeWriteOnlyStorageTextureSubresources);
+    SDL_zeroa(commandBuffer->computeWriteOnlyStorageBuffers);
+    SDL_zeroa(commandBuffer->computeUniformBuffers);
 
-    command_buffer->autoReleaseFence = true;
+    commandBuffer->autoReleaseFence = true;
 
-    return (SDL_GPUCommandBuffer *)command_buffer;
+    return (SDL_GPUCommandBuffer *)commandBuffer;
 }
 
 static SDL_GPUTexture *D3D12_AcquireSwapchainTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_Window *window,
     Uint32 *w,
     Uint32 *h)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Renderer *renderer = d3d12CommandBuffer->renderer;
     D3D12WindowData *windowData;
     Uint32 swapchainIndex;
@@ -6906,7 +6906,7 @@ static void D3D12_INTERNAL_PerformPendingDestroys(D3D12Renderer *renderer)
 }
 
 static void D3D12_INTERNAL_CopyTextureDownload(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12TextureDownload *download)
 {
     Uint8 *sourcePtr;
@@ -6957,87 +6957,87 @@ static void D3D12_INTERNAL_CopyTextureDownload(
 
 static void D3D12_INTERNAL_CleanCommandBuffer(
     D3D12Renderer *renderer,
-    D3D12CommandBuffer *command_buffer)
+    D3D12CommandBuffer *commandBuffer)
 {
     Uint32 i;
     HRESULT res;
 
     // Perform deferred texture data copies
 
-    for (i = 0; i < command_buffer->textureDownloadCount; i += 1) {
+    for (i = 0; i < commandBuffer->textureDownloadCount; i += 1) {
         D3D12_INTERNAL_CopyTextureDownload(
-            command_buffer,
-            command_buffer->textureDownloads[i]);
-        SDL_free(command_buffer->textureDownloads[i]);
+            commandBuffer,
+            commandBuffer->textureDownloads[i]);
+        SDL_free(commandBuffer->textureDownloads[i]);
     }
-    command_buffer->textureDownloadCount = 0;
+    commandBuffer->textureDownloadCount = 0;
 
-    res = ID3D12CommandAllocator_Reset(command_buffer->commandAllocator);
+    res = ID3D12CommandAllocator_Reset(commandBuffer->commandAllocator);
     ERROR_CHECK("Could not reset command allocator")
 
     res = ID3D12GraphicsCommandList_Reset(
-        command_buffer->graphicsCommandList,
-        command_buffer->commandAllocator,
+        commandBuffer->graphicsCommandList,
+        commandBuffer->commandAllocator,
         NULL);
     ERROR_CHECK("Could not reset graphicsCommandList")
 
     // Return descriptor heaps to pool
     D3D12_INTERNAL_ReturnDescriptorHeapToPool(
         renderer,
-        command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]);
+        commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]);
     D3D12_INTERNAL_ReturnDescriptorHeapToPool(
         renderer,
-        command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]);
+        commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]);
 
     // Uniform buffers are now available
     SDL_LockMutex(renderer->acquireUniformBufferLock);
 
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
         D3D12_INTERNAL_ReturnUniformBufferToPool(
             renderer,
-            command_buffer->usedUniformBuffers[i]);
+            commandBuffer->usedUniformBuffers[i]);
     }
-    command_buffer->usedUniformBufferCount = 0;
+    commandBuffer->usedUniformBufferCount = 0;
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
     // TODO: More reference counting
 
-    for (i = 0; i < command_buffer->usedTextureCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedTextures[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedTextureCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedTextures[i]->referenceCount);
     }
-    command_buffer->usedTextureCount = 0;
+    commandBuffer->usedTextureCount = 0;
 
-    for (i = 0; i < command_buffer->usedBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedBuffers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedBuffers[i]->referenceCount);
     }
-    command_buffer->usedBufferCount = 0;
+    commandBuffer->usedBufferCount = 0;
 
-    for (i = 0; i < command_buffer->usedSamplerCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedSamplers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedSamplerCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedSamplers[i]->referenceCount);
     }
-    command_buffer->usedSamplerCount = 0;
+    commandBuffer->usedSamplerCount = 0;
 
-    for (i = 0; i < command_buffer->usedGraphicsPipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedGraphicsPipelines[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedGraphicsPipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedGraphicsPipelines[i]->referenceCount);
     }
-    command_buffer->usedGraphicsPipelineCount = 0;
+    commandBuffer->usedGraphicsPipelineCount = 0;
 
-    for (i = 0; i < command_buffer->usedComputePipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedComputePipelines[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedComputePipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedComputePipelines[i]->referenceCount);
     }
-    command_buffer->usedComputePipelineCount = 0;
+    commandBuffer->usedComputePipelineCount = 0;
 
     // Reset presentation
-    command_buffer->presentDataCount = 0;
+    commandBuffer->presentDataCount = 0;
 
     // The fence is now available (unless SubmitAndAcquireFence was called)
-    if (command_buffer->autoReleaseFence) {
+    if (commandBuffer->autoReleaseFence) {
         D3D12_ReleaseFence(
             (SDL_GPURenderer *)renderer,
-            (SDL_GPUFence *)command_buffer->inFlightFence);
+            (SDL_GPUFence *)commandBuffer->inFlightFence);
 
-        command_buffer->inFlightFence = NULL;
+        commandBuffer->inFlightFence = NULL;
     }
 
     // Return command buffer to pool
@@ -7050,14 +7050,14 @@ static void D3D12_INTERNAL_CleanCommandBuffer(
             renderer->availableCommandBufferCapacity * sizeof(D3D12CommandBuffer *));
     }
 
-    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
+    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
     renderer->availableCommandBufferCount += 1;
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
     // Remove this command buffer from the submitted list
     for (i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-        if (renderer->submittedCommandBuffers[i] == command_buffer) {
+        if (renderer->submittedCommandBuffers[i] == commandBuffer) {
             renderer->submittedCommandBuffers[i] = renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount - 1];
             renderer->submittedCommandBufferCount -= 1;
         }
@@ -7065,9 +7065,9 @@ static void D3D12_INTERNAL_CleanCommandBuffer(
 }
 
 static void D3D12_Submit(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Renderer *renderer = d3d12CommandBuffer->renderer;
     ID3D12CommandList *commandLists[1];
     HRESULT res;
@@ -7221,11 +7221,11 @@ static void D3D12_Submit(
 }
 
 static SDL_GPUFence *D3D12_SubmitAndAcquireFence(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     d3d12CommandBuffer->autoReleaseFence = false;
-    D3D12_Submit(command_buffer);
+    D3D12_Submit(commandBuffer);
     return (SDL_GPUFence *)d3d12CommandBuffer->inFlightFence;
 }
 
@@ -7277,18 +7277,18 @@ static void D3D12_Wait(
 
 static void D3D12_WaitForFences(
     SDL_GPURenderer *driverData,
-    bool wait_all,
+    bool waitAll,
     SDL_GPUFence *const *fences,
-    Uint32 num_fences)
+    Uint32 numFences)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     D3D12Fence *fence;
-    HANDLE *events = SDL_stack_alloc(HANDLE, num_fences);
+    HANDLE *events = SDL_stack_alloc(HANDLE, numFences);
     HRESULT res;
 
     SDL_LockMutex(renderer->submitLock);
 
-    for (Uint32 i = 0; i < num_fences; i += 1) {
+    for (Uint32 i = 0; i < numFences; i += 1) {
         fence = (D3D12Fence *)fences[i];
 
         res = ID3D12Fence_SetEventOnCompletion(
@@ -7301,9 +7301,9 @@ static void D3D12_WaitForFences(
     }
 
     WaitForMultipleObjects(
-        num_fences,
+        numFences,
         events,
-        wait_all,
+        waitAll,
         INFINITE);
 
     // Check for cleanups
@@ -7385,7 +7385,7 @@ static bool D3D12_SupportsTextureFormat(
 static bool D3D12_SupportsSampleCount(
     SDL_GPURenderer *driverData,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sample_count)
+    SDL_GPUSampleCount sampleCount)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS featureData;
@@ -7397,7 +7397,7 @@ static bool D3D12_SupportsSampleCount(
     featureData.Flags = (D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS)0;
 #endif
     featureData.Format = SDLToD3D12_TextureFormat[format];
-    featureData.SampleCount = SDLToD3D12_SampleCount[sample_count];
+    featureData.SampleCount = SDLToD3D12_SampleCount[sampleCount];
     res = ID3D12Device_CheckFeatureSupport(
         renderer->device,
         D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
@@ -7521,13 +7521,13 @@ static void D3D12_INTERNAL_InitBlitResources(
     }
 }
 
-static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
+static bool D3D12_PrepareDriver(SDL_VideoDevice *this)
 {
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
     return true;
 #else
-    void *d3d12_dll;
-    void *dxgi_dll;
+    void *d3d12Dll;
+    void *dxgiDll;
     PFN_D3D12_CREATE_DEVICE D3D12CreateDeviceFunc;
     PFN_CREATE_DXGI_FACTORY1 CreateDXGIFactoryFunc;
     HRESULT res;
@@ -7539,35 +7539,35 @@ static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
 
     // Can we load D3D12?
 
-    d3d12_dll = SDL_LoadObject(D3D12_DLL);
-    if (d3d12_dll == NULL) {
+    d3d12Dll = SDL_LoadObject(D3D12_DLL);
+    if (d3d12Dll == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D12: Could not find " D3D12_DLL);
         return false;
     }
 
     D3D12CreateDeviceFunc = (PFN_D3D12_CREATE_DEVICE)SDL_LoadFunction(
-        d3d12_dll,
+        d3d12Dll,
         D3D12_CREATE_DEVICE_FUNC);
     if (D3D12CreateDeviceFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D12: Could not find function " D3D12_CREATE_DEVICE_FUNC " in " D3D12_DLL);
-        SDL_UnloadObject(d3d12_dll);
+        SDL_UnloadObject(d3d12Dll);
         return false;
     }
 
     // Can we load DXGI?
 
-    dxgi_dll = SDL_LoadObject(DXGI_DLL);
-    if (dxgi_dll == NULL) {
+    dxgiDll = SDL_LoadObject(DXGI_DLL);
+    if (dxgiDll == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D12: Could not find " DXGI_DLL);
         return false;
     }
 
     CreateDXGIFactoryFunc = (PFN_CREATE_DXGI_FACTORY1)SDL_LoadFunction(
-        dxgi_dll,
+        dxgiDll,
         CREATE_DXGI_FACTORY1_FUNC);
     if (CreateDXGIFactoryFunc == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D12: Could not find function " CREATE_DXGI_FACTORY1_FUNC " in " DXGI_DLL);
-        SDL_UnloadObject(dxgi_dll);
+        SDL_UnloadObject(dxgiDll);
         return false;
     }
 
@@ -7579,8 +7579,8 @@ static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
         (void **)&factory);
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D12: Could not create DXGIFactory");
-        SDL_UnloadObject(d3d12_dll);
-        SDL_UnloadObject(dxgi_dll);
+        SDL_UnloadObject(d3d12Dll);
+        SDL_UnloadObject(dxgiDll);
         return false;
     }
 
@@ -7592,8 +7592,8 @@ static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
     if (FAILED(res)) {
         IDXGIFactory1_Release(factory);
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D12: Failed to find DXGI1.4 support, required for DX12");
-        SDL_UnloadObject(d3d12_dll);
-        SDL_UnloadObject(dxgi_dll);
+        SDL_UnloadObject(d3d12Dll);
+        SDL_UnloadObject(dxgiDll);
         return false;
     }
     IDXGIFactory4_Release(factory4);
@@ -7619,8 +7619,8 @@ static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D12: Failed to find adapter for D3D12Device");
         IDXGIFactory1_Release(factory);
-        SDL_UnloadObject(d3d12_dll);
-        SDL_UnloadObject(dxgi_dll);
+        SDL_UnloadObject(d3d12Dll);
+        SDL_UnloadObject(dxgiDll);
         return false;
     }
 
@@ -7636,8 +7636,8 @@ static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
     IDXGIAdapter1_Release(adapter);
     IDXGIFactory1_Release(factory);
 
-    SDL_UnloadObject(d3d12_dll);
-    SDL_UnloadObject(dxgi_dll);
+    SDL_UnloadObject(d3d12Dll);
+    SDL_UnloadObject(dxgiDll);
 
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "D3D12: Could not create D3D12Device with feature level " D3D_FEATURE_LEVEL_CHOICE_STR);
@@ -7739,7 +7739,7 @@ static void D3D12_INTERNAL_TryInitializeD3D12DebugInfoQueue(D3D12Renderer *rende
 }
 #endif
 
-static SDL_GPUDevice *D3D12_CreateDevice(bool debug_mode, bool preferLowPower, SDL_PropertiesID props)
+static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
 {
     SDL_GPUDevice *result;
     D3D12Renderer *renderer;
@@ -7772,7 +7772,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debug_mode, bool preferLowPower, S
 
 #ifdef HAVE_IDXGIINFOQUEUE
     // Initialize the DXGI debug layer, if applicable
-    if (debug_mode) {
+    if (debugMode) {
         D3D12_INTERNAL_TryInitializeDXGIDebug(renderer);
     }
 #endif
@@ -7899,7 +7899,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debug_mode, bool preferLowPower, S
     }
 
     // Initialize the D3D12 debug layer, if applicable
-    if (debug_mode) {
+    if (debugMode) {
         D3D12_INTERNAL_TryInitializeD3D12Debug(renderer);
     }
 
@@ -7966,7 +7966,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debug_mode, bool preferLowPower, S
     }
 
     // Initialize the D3D12 debug info queue, if applicable
-    if (debug_mode) {
+    if (debugMode) {
         D3D12_INTERNAL_TryInitializeD3D12DebugInfoQueue(renderer);
     }
 #endif
@@ -8202,7 +8202,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debug_mode, bool preferLowPower, S
     renderer->fenceLock = SDL_CreateMutex();
     renderer->disposeLock = SDL_CreateMutex();
 
-    renderer->debug_mode = debug_mode;
+    renderer->debug_mode = debugMode;
 
     renderer->semantic = SDL_GetStringProperty(props, SDL_PROP_GPU_DEVICE_CREATE_D3D12_SEMANTIC_NAME_STRING, "TEXCOORD");
 
@@ -8219,7 +8219,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debug_mode, bool preferLowPower, S
 
     ASSIGN_DRIVER(D3D12)
     result->driverData = (SDL_GPURenderer *)renderer;
-    result->debug_mode = debug_mode;
+    result->debug_mode = debugMode;
     renderer->sdlGPUDevice = result;
 
     return result;

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -3350,7 +3350,7 @@ static bool METAL_SupportsSwapchainComposition(
     SDL_GPUSwapchainComposition swapchainComposition)
 {
 #ifndef SDL_PLATFORM_MACOS
-    if (swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048) {
+    if (swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048) {
         return false;
     }
 #endif

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -2355,12 +2355,12 @@ static void METAL_BindVertexBuffers(
 
 static void METAL_BindIndexBuffer(
     SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUBufferBinding *pBinding,
+    const SDL_GPUBufferBinding *binding,
     SDL_GPUIndexElementSize index_element_size)
 {
     MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
-    metalCommandBuffer->indexBuffer = ((MetalBufferContainer *)pBinding->buffer)->activeBuffer;
-    metalCommandBuffer->indexBufferOffset = pBinding->offset;
+    metalCommandBuffer->indexBuffer = ((MetalBufferContainer *)binding->buffer)->activeBuffer;
+    metalCommandBuffer->indexBufferOffset = binding->offset;
     metalCommandBuffer->index_element_size = index_element_size;
 
     METAL_INTERNAL_TrackBuffer(metalCommandBuffer, metalCommandBuffer->indexBuffer);

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -312,17 +312,17 @@ static SDL_GPUTextureFormat SwapchainCompositionToFormat[] = {
 static CFStringRef SwapchainCompositionToColorSpace[4]; // initialized on device creation
 
 static MTLStoreAction SDLToMetal_StoreOp(
-    SDL_GPUStoreOp store_op,
+    SDL_GPUStoreOp storeOp,
     Uint8 isMultisample)
 {
     if (isMultisample) {
-        if (store_op == SDL_GPU_STOREOP_STORE) {
+        if (storeOp == SDL_GPU_STOREOP_STORE) {
             return MTLStoreActionStoreAndMultisampleResolve;
         } else {
             return MTLStoreActionMultisampleResolve;
         }
     } else {
-        if (store_op == SDL_GPU_STOREOP_STORE) {
+        if (storeOp == SDL_GPU_STOREOP_STORE) {
             return MTLStoreActionStore;
         } else {
             return MTLStoreActionDontCare;
@@ -393,9 +393,9 @@ typedef struct MetalShader
     id<MTLFunction> function;
 
     Uint32 num_samplers;
-    Uint32 num_uniform_buffers;
-    Uint32 num_storage_buffers;
-    Uint32 num_storage_textures;
+    Uint32 numUniformBuffers;
+    Uint32 numStorageBuffers;
+    Uint32 numStorageTextures;
 } MetalShader;
 
 typedef struct MetalGraphicsPipeline
@@ -404,8 +404,8 @@ typedef struct MetalGraphicsPipeline
 
     Uint32 sample_mask;
 
-    SDL_GPURasterizerState rasterizer_state;
-    SDL_GPUPrimitiveType primitive_type;
+    SDL_GPURasterizerState rasterizerState;
+    SDL_GPUPrimitiveType primitiveType;
 
     id<MTLDepthStencilState> depth_stencil_state;
 
@@ -427,7 +427,7 @@ typedef struct MetalComputePipeline
     Uint32 num_writeonly_storage_textures;
     Uint32 num_readonly_storage_buffers;
     Uint32 num_writeonly_storage_buffers;
-    Uint32 num_uniform_buffers;
+    Uint32 numUniformBuffers;
     Uint32 threadcount_x;
     Uint32 threadcount_y;
     Uint32 threadcount_z;
@@ -660,12 +660,12 @@ static void METAL_DestroyDevice(SDL_GPUDevice *device)
 
     // Release command buffer infrastructure
     for (Uint32 i = 0; i < renderer->availableCommandBufferCount; i += 1) {
-        MetalCommandBuffer *command_buffer = renderer->availableCommandBuffers[i];
-        SDL_free(command_buffer->usedBuffers);
-        SDL_free(command_buffer->usedTextures);
-        SDL_free(command_buffer->usedUniformBuffers);
-        SDL_free(command_buffer->windowDatas);
-        SDL_free(command_buffer);
+        MetalCommandBuffer *commandBuffer = renderer->availableCommandBuffers[i];
+        SDL_free(commandBuffer->usedBuffers);
+        SDL_free(commandBuffer->usedTextures);
+        SDL_free(commandBuffer->usedUniformBuffers);
+        SDL_free(commandBuffer->windowDatas);
+        SDL_free(commandBuffer);
     }
     SDL_free(renderer->availableCommandBuffers);
     SDL_free(renderer->submittedCommandBuffers);
@@ -719,25 +719,25 @@ static void METAL_INTERNAL_TrackTexture(
 }
 
 static void METAL_INTERNAL_TrackUniformBuffer(
-    MetalCommandBuffer *command_buffer,
+    MetalCommandBuffer *commandBuffer,
     MetalUniformBuffer *uniformBuffer)
 {
     Uint32 i;
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
-        if (command_buffer->usedUniformBuffers[i] == uniformBuffer) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
+        if (commandBuffer->usedUniformBuffers[i] == uniformBuffer) {
             return;
         }
     }
 
-    if (command_buffer->usedUniformBufferCount == command_buffer->usedUniformBufferCapacity) {
-        command_buffer->usedUniformBufferCapacity += 1;
-        command_buffer->usedUniformBuffers = SDL_realloc(
-            command_buffer->usedUniformBuffers,
-            command_buffer->usedUniformBufferCapacity * sizeof(MetalUniformBuffer *));
+    if (commandBuffer->usedUniformBufferCount == commandBuffer->usedUniformBufferCapacity) {
+        commandBuffer->usedUniformBufferCapacity += 1;
+        commandBuffer->usedUniformBuffers = SDL_realloc(
+            commandBuffer->usedUniformBuffers,
+            commandBuffer->usedUniformBufferCapacity * sizeof(MetalUniformBuffer *));
     }
 
-    command_buffer->usedUniformBuffers[command_buffer->usedUniformBufferCount] = uniformBuffer;
-    command_buffer->usedUniformBufferCount += 1;
+    commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
+    commandBuffer->usedUniformBufferCount += 1;
 }
 
 // Shader Compilation
@@ -753,8 +753,8 @@ static MetalLibraryFunction METAL_INTERNAL_CompileShader(
     MetalRenderer *renderer,
     SDL_GPUShaderFormat format,
     const Uint8 *code,
-    size_t code_size,
-    const char *entrypoint_name)
+    size_t codeSize,
+    const char *entrypoint)
 {
     MetalLibraryFunction libraryFunction = { nil, nil };
     id<MTLLibrary> library;
@@ -765,7 +765,7 @@ static MetalLibraryFunction METAL_INTERNAL_CompileShader(
     if (format == SDL_GPU_SHADERFORMAT_MSL) {
         NSString *codeString = [[NSString alloc]
             initWithBytes:code
-                   length:code_size
+                   length:codeSize
                  encoding:NSUTF8StringEncoding];
         library = [renderer->device
             newLibraryWithSource:codeString
@@ -774,7 +774,7 @@ static MetalLibraryFunction METAL_INTERNAL_CompileShader(
     } else if (format == SDL_GPU_SHADERFORMAT_METALLIB) {
         data = dispatch_data_create(
             code,
-            code_size,
+            codeSize,
             dispatch_get_global_queue(0, 0),
             ^{ /* do nothing */ });
         library = [renderer->device newLibraryWithData:data error:&error];
@@ -796,7 +796,7 @@ static MetalLibraryFunction METAL_INTERNAL_CompileShader(
             [[error description] cStringUsingEncoding:[NSString defaultCStringEncoding]]);
     }
 
-    function = [library newFunctionWithName:@(entrypoint_name)];
+    function = [library newFunctionWithName:@(entrypoint)];
     if (function == nil) {
         SDL_LogError(
             SDL_LOG_CATEGORY_GPU,
@@ -897,11 +897,11 @@ static void METAL_ReleaseBuffer(
 
 static void METAL_ReleaseTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     METAL_ReleaseBuffer(
         driverData,
-        (SDL_GPUBuffer *)transfer_buffer);
+        (SDL_GPUBuffer *)transferBuffer);
 }
 
 static void METAL_ReleaseShader(
@@ -918,10 +918,10 @@ static void METAL_ReleaseShader(
 
 static void METAL_ReleaseComputePipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUComputePipeline *computePipeline)
 {
     @autoreleasepool {
-        MetalComputePipeline *metalComputePipeline = (MetalComputePipeline *)compute_pipeline;
+        MetalComputePipeline *metalComputePipeline = (MetalComputePipeline *)computePipeline;
         metalComputePipeline->handle = nil;
         SDL_free(metalComputePipeline);
     }
@@ -929,10 +929,10 @@ static void METAL_ReleaseComputePipeline(
 
 static void METAL_ReleaseGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
     @autoreleasepool {
-        MetalGraphicsPipeline *metalGraphicsPipeline = (MetalGraphicsPipeline *)graphics_pipeline;
+        MetalGraphicsPipeline *metalGraphicsPipeline = (MetalGraphicsPipeline *)graphicsPipeline;
         metalGraphicsPipeline->handle = nil;
         metalGraphicsPipeline->depth_stencil_state = nil;
         SDL_free(metalGraphicsPipeline);
@@ -957,7 +957,7 @@ static SDL_GPUComputePipeline *METAL_CreateComputePipeline(
             createinfo->format,
             createinfo->code,
             createinfo->code_size,
-            createinfo->entrypoint_name);
+            createinfo->entrypoint);
 
         if (libraryFunction.library == nil || libraryFunction.function == nil) {
             return NULL;
@@ -977,7 +977,7 @@ static SDL_GPUComputePipeline *METAL_CreateComputePipeline(
         pipeline->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
         pipeline->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
         pipeline->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
-        pipeline->num_uniform_buffers = createinfo->num_uniform_buffers;
+        pipeline->numUniformBuffers = createinfo->num_uniform_buffers;
         pipeline->threadcount_x = createinfo->threadcount_x;
         pipeline->threadcount_y = createinfo->threadcount_y;
         pipeline->threadcount_z = createinfo->threadcount_z;
@@ -992,16 +992,16 @@ static SDL_GPUGraphicsPipeline *METAL_CreateGraphicsPipeline(
 {
     @autoreleasepool {
         MetalRenderer *renderer = (MetalRenderer *)driverData;
-        MetalShader *vertex_shader = (MetalShader *)createinfo->vertex_shader;
-        MetalShader *fragment_shader = (MetalShader *)createinfo->fragment_shader;
+        MetalShader *vertexShader = (MetalShader *)createinfo->vertex_shader;
+        MetalShader *fragmentShader = (MetalShader *)createinfo->fragment_shader;
         MTLRenderPipelineDescriptor *pipelineDescriptor;
-        const SDL_GPUColorTargetBlendState *blend_state;
+        const SDL_GPUColorTargetBlendState *blendState;
         MTLVertexDescriptor *vertexDescriptor;
         Uint32 binding;
         MTLDepthStencilDescriptor *depthStencilDescriptor;
         MTLStencilDescriptor *frontStencilDescriptor = NULL;
         MTLStencilDescriptor *backStencilDescriptor = NULL;
-        id<MTLDepthStencilState> depth_stencil_state = nil;
+        id<MTLDepthStencilState> depthStencilState = nil;
         id<MTLRenderPipelineState> pipelineState = nil;
         NSError *error = NULL;
         MetalGraphicsPipeline *result = NULL;
@@ -1011,17 +1011,17 @@ static SDL_GPUGraphicsPipeline *METAL_CreateGraphicsPipeline(
         // Blend
 
         for (Uint32 i = 0; i < createinfo->target_info.num_color_targets; i += 1) {
-            blend_state = &createinfo->target_info.color_target_descriptions[i].blend_state;
+            blendState = &createinfo->target_info.color_target_descriptions[i].blend_state;
 
             pipelineDescriptor.colorAttachments[i].pixelFormat = SDLToMetal_SurfaceFormat[createinfo->target_info.color_target_descriptions[i].format];
-            pipelineDescriptor.colorAttachments[i].writeMask = SDLToMetal_ColorWriteMask(blend_state->color_write_mask);
-            pipelineDescriptor.colorAttachments[i].blendingEnabled = blend_state->enable_blend;
-            pipelineDescriptor.colorAttachments[i].rgbBlendOperation = SDLToMetal_BlendOp[blend_state->color_blend_op];
-            pipelineDescriptor.colorAttachments[i].alphaBlendOperation = SDLToMetal_BlendOp[blend_state->alpha_blend_op];
-            pipelineDescriptor.colorAttachments[i].sourceRGBBlendFactor = SDLToMetal_BlendFactor[blend_state->src_color_blendfactor];
-            pipelineDescriptor.colorAttachments[i].sourceAlphaBlendFactor = SDLToMetal_BlendFactor[blend_state->src_alpha_blendfactor];
-            pipelineDescriptor.colorAttachments[i].destinationRGBBlendFactor = SDLToMetal_BlendFactor[blend_state->dst_color_blendfactor];
-            pipelineDescriptor.colorAttachments[i].destinationAlphaBlendFactor = SDLToMetal_BlendFactor[blend_state->dst_alpha_blendfactor];
+            pipelineDescriptor.colorAttachments[i].writeMask = SDLToMetal_ColorWriteMask(blendState->color_write_mask);
+            pipelineDescriptor.colorAttachments[i].blendingEnabled = blendState->enable_blend;
+            pipelineDescriptor.colorAttachments[i].rgbBlendOperation = SDLToMetal_BlendOp[blendState->color_blend_op];
+            pipelineDescriptor.colorAttachments[i].alphaBlendOperation = SDLToMetal_BlendOp[blendState->alpha_blend_op];
+            pipelineDescriptor.colorAttachments[i].sourceRGBBlendFactor = SDLToMetal_BlendFactor[blendState->src_color_blendfactor];
+            pipelineDescriptor.colorAttachments[i].sourceAlphaBlendFactor = SDLToMetal_BlendFactor[blendState->src_alpha_blendfactor];
+            pipelineDescriptor.colorAttachments[i].destinationRGBBlendFactor = SDLToMetal_BlendFactor[blendState->dst_color_blendfactor];
+            pipelineDescriptor.colorAttachments[i].destinationAlphaBlendFactor = SDLToMetal_BlendFactor[blendState->dst_alpha_blendfactor];
         }
 
         // Multisample
@@ -1059,13 +1059,13 @@ static SDL_GPUGraphicsPipeline *METAL_CreateGraphicsPipeline(
             depthStencilDescriptor.frontFaceStencil = frontStencilDescriptor;
             depthStencilDescriptor.backFaceStencil = backStencilDescriptor;
 
-            depth_stencil_state = [renderer->device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
+            depthStencilState = [renderer->device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
         }
 
         // Shaders
 
-        pipelineDescriptor.vertexFunction = vertex_shader->function;
-        pipelineDescriptor.fragmentFunction = fragment_shader->function;
+        pipelineDescriptor.vertexFunction = vertexShader->function;
+        pipelineDescriptor.fragmentFunction = fragmentShader->function;
 
         // Vertex Descriptor
 
@@ -1102,17 +1102,17 @@ static SDL_GPUGraphicsPipeline *METAL_CreateGraphicsPipeline(
         result = SDL_calloc(1, sizeof(MetalGraphicsPipeline));
         result->handle = pipelineState;
         result->sample_mask = createinfo->multisample_state.sample_mask;
-        result->depth_stencil_state = depth_stencil_state;
-        result->rasterizer_state = createinfo->rasterizer_state;
-        result->primitive_type = createinfo->primitive_type;
-        result->vertexSamplerCount = vertex_shader->num_samplers;
-        result->vertexUniformBufferCount = vertex_shader->num_uniform_buffers;
-        result->vertexStorageBufferCount = vertex_shader->num_storage_buffers;
-        result->vertexStorageTextureCount = vertex_shader->num_storage_textures;
-        result->fragmentSamplerCount = fragment_shader->num_samplers;
-        result->fragmentUniformBufferCount = fragment_shader->num_uniform_buffers;
-        result->fragmentStorageBufferCount = fragment_shader->num_storage_buffers;
-        result->fragmentStorageTextureCount = fragment_shader->num_storage_textures;
+        result->depth_stencil_state = depthStencilState;
+        result->rasterizerState = createinfo->rasterizer_state;
+        result->primitiveType = createinfo->primitive_type;
+        result->vertexSamplerCount = vertexShader->num_samplers;
+        result->vertexUniformBufferCount = vertexShader->numUniformBuffers;
+        result->vertexStorageBufferCount = vertexShader->numStorageBuffers;
+        result->vertexStorageTextureCount = vertexShader->numStorageTextures;
+        result->fragmentSamplerCount = fragmentShader->num_samplers;
+        result->fragmentUniformBufferCount = fragmentShader->numUniformBuffers;
+        result->fragmentStorageBufferCount = fragmentShader->numStorageBuffers;
+        result->fragmentStorageTextureCount = fragmentShader->numStorageTextures;
         return (SDL_GPUGraphicsPipeline *)result;
     }
 }
@@ -1174,11 +1174,11 @@ static void METAL_SetTextureName(
 }
 
 static void METAL_InsertDebugLabel(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *text)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         NSString *label = @(text);
 
         if (metalCommandBuffer->renderEncoder) {
@@ -1196,11 +1196,11 @@ static void METAL_InsertDebugLabel(
 }
 
 static void METAL_PushDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *name)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         NSString *label = @(name);
 
         if (metalCommandBuffer->renderEncoder) {
@@ -1216,10 +1216,10 @@ static void METAL_PushDebugGroup(
 }
 
 static void METAL_PopDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
 
         if (metalCommandBuffer->renderEncoder) {
             [metalCommandBuffer->renderEncoder popDebugGroup];
@@ -1282,7 +1282,7 @@ static SDL_GPUShader *METAL_CreateShader(
             createinfo->format,
             createinfo->code,
             createinfo->code_size,
-            createinfo->entrypoint_name);
+            createinfo->entrypoint);
 
         if (libraryFunction.library == nil || libraryFunction.function == nil) {
             return NULL;
@@ -1292,9 +1292,9 @@ static SDL_GPUShader *METAL_CreateShader(
         result->library = libraryFunction.library;
         result->function = libraryFunction.function;
         result->num_samplers = createinfo->num_samplers;
-        result->num_storage_buffers = createinfo->num_storage_buffers;
-        result->num_storage_textures = createinfo->num_storage_textures;
-        result->num_uniform_buffers = createinfo->num_uniform_buffers;
+        result->numStorageBuffers = createinfo->num_storage_buffers;
+        result->numStorageTextures = createinfo->num_storage_textures;
+        result->numUniformBuffers = createinfo->num_uniform_buffers;
         return (SDL_GPUShader *)result;
     }
 }
@@ -1329,16 +1329,16 @@ static MetalTexture *METAL_INTERNAL_CreateTexture(
     textureDescriptor.storageMode = MTLStorageModePrivate;
 
     textureDescriptor.usage = 0;
-    if (createinfo->usage_flags & (SDL_GPU_TEXTUREUSAGE_COLOR_TARGET |
-                                   SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
+    if (createinfo->usage & (SDL_GPU_TEXTUREUSAGE_COLOR_TARGET |
+                             SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
         textureDescriptor.usage |= MTLTextureUsageRenderTarget;
     }
-    if (createinfo->usage_flags & (SDL_GPU_TEXTUREUSAGE_SAMPLER |
-                                   SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ |
-                                   SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ)) {
+    if (createinfo->usage & (SDL_GPU_TEXTUREUSAGE_SAMPLER |
+                             SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ |
+                             SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ)) {
         textureDescriptor.usage |= MTLTextureUsageShaderRead;
     }
-    if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+    if (createinfo->usage & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
         textureDescriptor.usage |= MTLTextureUsageShaderWrite;
     }
 
@@ -1371,11 +1371,11 @@ static MetalTexture *METAL_INTERNAL_CreateTexture(
 static bool METAL_SupportsSampleCount(
     SDL_GPURenderer *driverData,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sample_count)
+    SDL_GPUSampleCount sampleCount)
 {
     @autoreleasepool {
         MetalRenderer *renderer = (MetalRenderer *)driverData;
-        NSUInteger mtlSampleCount = SDLToMetal_SampleCount[sample_count];
+        NSUInteger mtlSampleCount = SDLToMetal_SampleCount[sampleCount];
         return [renderer->device supportsTextureSampleCount:mtlSampleCount];
     }
 }
@@ -1517,7 +1517,7 @@ static MetalBufferContainer *METAL_INTERNAL_CreateBufferContainer(
 
 static SDL_GPUBuffer *METAL_CreateBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usage,
     Uint32 size)
 {
     @autoreleasepool {
@@ -1620,12 +1620,12 @@ static MetalBuffer *METAL_INTERNAL_PrepareBufferForWrite(
 
 static void *METAL_MapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer,
+    SDL_GPUTransferBuffer *transferBuffer,
     bool cycle)
 {
     @autoreleasepool {
         MetalRenderer *renderer = (MetalRenderer *)driverData;
-        MetalBufferContainer *container = (MetalBufferContainer *)transfer_buffer;
+        MetalBufferContainer *container = (MetalBufferContainer *)transferBuffer;
         MetalBuffer *buffer = METAL_INTERNAL_PrepareBufferForWrite(renderer, container, cycle);
         return [buffer->handle contents];
     }
@@ -1633,12 +1633,12 @@ static void *METAL_MapTransferBuffer(
 
 static void METAL_UnmapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
 #ifdef SDL_PLATFORM_MACOS
     @autoreleasepool {
         // FIXME: Is this necessary?
-        MetalBufferContainer *container = (MetalBufferContainer *)transfer_buffer;
+        MetalBufferContainer *container = (MetalBufferContainer *)transferBuffer;
         MetalBuffer *buffer = container->activeBuffer;
         if (buffer->handle.storageMode == MTLStorageModeManaged) {
             [buffer->handle didModifyRange:NSMakeRange(0, container->size)];
@@ -1650,22 +1650,22 @@ static void METAL_UnmapTransferBuffer(
 // Copy Pass
 
 static void METAL_BeginCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         metalCommandBuffer->blitEncoder = [metalCommandBuffer->handle blitCommandEncoder];
     }
 }
 
 static void METAL_UploadToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalRenderer *renderer = metalCommandBuffer->renderer;
         MetalBufferContainer *bufferContainer = (MetalBufferContainer *)source->transfer_buffer;
         MetalTextureContainer *textureContainer = (MetalTextureContainer *)destination->texture;
@@ -1689,13 +1689,13 @@ static void METAL_UploadToTexture(
 }
 
 static void METAL_UploadToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalRenderer *renderer = metalCommandBuffer->renderer;
         MetalBufferContainer *transferContainer = (MetalBufferContainer *)source->transfer_buffer;
         MetalBufferContainer *bufferContainer = (MetalBufferContainer *)destination->buffer;
@@ -1718,7 +1718,7 @@ static void METAL_UploadToBuffer(
 }
 
 static void METAL_CopyTextureToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -1727,7 +1727,7 @@ static void METAL_CopyTextureToTexture(
     bool cycle)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalRenderer *renderer = metalCommandBuffer->renderer;
         MetalTextureContainer *srcContainer = (MetalTextureContainer *)source->texture;
         MetalTextureContainer *dstContainer = (MetalTextureContainer *)destination->texture;
@@ -1755,14 +1755,14 @@ static void METAL_CopyTextureToTexture(
 }
 
 static void METAL_CopyBufferToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     bool cycle)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalRenderer *renderer = metalCommandBuffer->renderer;
         MetalBufferContainer *srcContainer = (MetalBufferContainer *)source->buffer;
         MetalBufferContainer *dstContainer = (MetalBufferContainer *)destination->buffer;
@@ -1786,12 +1786,12 @@ static void METAL_CopyBufferToBuffer(
 }
 
 static void METAL_DownloadFromTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalRenderer *renderer = metalCommandBuffer->renderer;
         MetalTextureContainer *textureContainer = (MetalTextureContainer *)source->texture;
         MetalTexture *metalTexture = textureContainer->activeTexture;
@@ -1840,7 +1840,7 @@ static void METAL_DownloadFromTexture(
 }
 
 static void METAL_DownloadFromBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
@@ -1849,7 +1849,7 @@ static void METAL_DownloadFromBuffer(
     sourceLocation.offset = source->offset;
 
     METAL_CopyBufferToBuffer(
-        command_buffer,
+        commandBuffer,
         &sourceLocation,
         (SDL_GPUBufferLocation *)destination,
         source->size,
@@ -1857,28 +1857,28 @@ static void METAL_DownloadFromBuffer(
 }
 
 static void METAL_EndCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         [metalCommandBuffer->blitEncoder endEncoding];
         metalCommandBuffer->blitEncoder = nil;
     }
 }
 
 static void METAL_GenerateMipmaps(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUTexture *texture)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalTextureContainer *container = (MetalTextureContainer *)texture;
         MetalTexture *metalTexture = container->activeTexture;
 
-        METAL_BeginCopyPass(command_buffer);
+        METAL_BeginCopyPass(commandBuffer);
         [metalCommandBuffer->blitEncoder
             generateMipmapsForTexture:metalTexture->handle];
-        METAL_EndCopyPass(command_buffer);
+        METAL_EndCopyPass(commandBuffer);
 
         METAL_INTERNAL_TrackTexture(metalCommandBuffer, metalTexture);
     }
@@ -1890,7 +1890,7 @@ static void METAL_INTERNAL_AllocateCommandBuffers(
     MetalRenderer *renderer,
     Uint32 allocateCount)
 {
-    MetalCommandBuffer *command_buffer;
+    MetalCommandBuffer *commandBuffer;
 
     renderer->availableCommandBufferCapacity += allocateCount;
 
@@ -1899,28 +1899,28 @@ static void METAL_INTERNAL_AllocateCommandBuffers(
         sizeof(MetalCommandBuffer *) * renderer->availableCommandBufferCapacity);
 
     for (Uint32 i = 0; i < allocateCount; i += 1) {
-        command_buffer = SDL_calloc(1, sizeof(MetalCommandBuffer));
-        command_buffer->renderer = renderer;
+        commandBuffer = SDL_calloc(1, sizeof(MetalCommandBuffer));
+        commandBuffer->renderer = renderer;
 
         // The native Metal command buffer is created in METAL_AcquireCommandBuffer
 
-        command_buffer->windowDataCapacity = 1;
-        command_buffer->windowDataCount = 0;
-        command_buffer->windowDatas = SDL_calloc(
-            command_buffer->windowDataCapacity, sizeof(MetalWindowData *));
+        commandBuffer->windowDataCapacity = 1;
+        commandBuffer->windowDataCount = 0;
+        commandBuffer->windowDatas = SDL_calloc(
+            commandBuffer->windowDataCapacity, sizeof(MetalWindowData *));
 
         // Reference Counting
-        command_buffer->usedBufferCapacity = 4;
-        command_buffer->usedBufferCount = 0;
-        command_buffer->usedBuffers = SDL_calloc(
-            command_buffer->usedBufferCapacity, sizeof(MetalBuffer *));
+        commandBuffer->usedBufferCapacity = 4;
+        commandBuffer->usedBufferCount = 0;
+        commandBuffer->usedBuffers = SDL_calloc(
+            commandBuffer->usedBufferCapacity, sizeof(MetalBuffer *));
 
-        command_buffer->usedTextureCapacity = 4;
-        command_buffer->usedTextureCount = 0;
-        command_buffer->usedTextures = SDL_calloc(
-            command_buffer->usedTextureCapacity, sizeof(MetalTexture *));
+        commandBuffer->usedTextureCapacity = 4;
+        commandBuffer->usedTextureCount = 0;
+        commandBuffer->usedTextures = SDL_calloc(
+            commandBuffer->usedTextureCapacity, sizeof(MetalTexture *));
 
-        renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
+        renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
         renderer->availableCommandBufferCount += 1;
     }
 }
@@ -1928,7 +1928,7 @@ static void METAL_INTERNAL_AllocateCommandBuffers(
 static MetalCommandBuffer *METAL_INTERNAL_GetInactiveCommandBufferFromPool(
     MetalRenderer *renderer)
 {
-    MetalCommandBuffer *command_buffer;
+    MetalCommandBuffer *commandBuffer;
 
     if (renderer->availableCommandBufferCount == 0) {
         METAL_INTERNAL_AllocateCommandBuffers(
@@ -1936,10 +1936,10 @@ static MetalCommandBuffer *METAL_INTERNAL_GetInactiveCommandBufferFromPool(
             renderer->availableCommandBufferCapacity);
     }
 
-    command_buffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
+    commandBuffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
     renderer->availableCommandBufferCount -= 1;
 
-    return command_buffer;
+    return commandBuffer;
 }
 
 static Uint8 METAL_INTERNAL_CreateFence(
@@ -1968,7 +1968,7 @@ static Uint8 METAL_INTERNAL_CreateFence(
 
 static Uint8 METAL_INTERNAL_AcquireFence(
     MetalRenderer *renderer,
-    MetalCommandBuffer *command_buffer)
+    MetalCommandBuffer *commandBuffer)
 {
     MetalFence *fence;
 
@@ -1989,7 +1989,7 @@ static Uint8 METAL_INTERNAL_AcquireFence(
     SDL_UnlockMutex(renderer->fenceLock);
 
     // Associate the fence with the command buffer
-    command_buffer->fence = fence;
+    commandBuffer->fence = fence;
     SDL_AtomicSet(&fence->complete, 0); // FIXME: Is this right?
 
     return 1;
@@ -2000,48 +2000,48 @@ static SDL_GPUCommandBuffer *METAL_AcquireCommandBuffer(
 {
     @autoreleasepool {
         MetalRenderer *renderer = (MetalRenderer *)driverData;
-        MetalCommandBuffer *command_buffer;
+        MetalCommandBuffer *commandBuffer;
 
         SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-        command_buffer = METAL_INTERNAL_GetInactiveCommandBufferFromPool(renderer);
-        command_buffer->handle = [renderer->queue commandBuffer];
+        commandBuffer = METAL_INTERNAL_GetInactiveCommandBufferFromPool(renderer);
+        commandBuffer->handle = [renderer->queue commandBuffer];
 
-        command_buffer->graphics_pipeline = NULL;
-        command_buffer->compute_pipeline = NULL;
+        commandBuffer->graphics_pipeline = NULL;
+        commandBuffer->compute_pipeline = NULL;
         for (Uint32 i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-            command_buffer->vertexUniformBuffers[i] = NULL;
-            command_buffer->fragmentUniformBuffers[i] = NULL;
-            command_buffer->computeUniformBuffers[i] = NULL;
+            commandBuffer->vertexUniformBuffers[i] = NULL;
+            commandBuffer->fragmentUniformBuffers[i] = NULL;
+            commandBuffer->computeUniformBuffers[i] = NULL;
         }
 
         // FIXME: Do we actually need to set this?
-        command_buffer->needVertexSamplerBind = true;
-        command_buffer->needVertexStorageTextureBind = true;
-        command_buffer->needVertexStorageBufferBind = true;
-        command_buffer->needVertexUniformBind = true;
-        command_buffer->needFragmentSamplerBind = true;
-        command_buffer->needFragmentStorageTextureBind = true;
-        command_buffer->needFragmentStorageBufferBind = true;
-        command_buffer->needFragmentUniformBind = true;
-        command_buffer->needComputeBufferBind = true;
-        command_buffer->needComputeTextureBind = true;
-        command_buffer->needComputeUniformBind = true;
+        commandBuffer->needVertexSamplerBind = true;
+        commandBuffer->needVertexStorageTextureBind = true;
+        commandBuffer->needVertexStorageBufferBind = true;
+        commandBuffer->needVertexUniformBind = true;
+        commandBuffer->needFragmentSamplerBind = true;
+        commandBuffer->needFragmentStorageTextureBind = true;
+        commandBuffer->needFragmentStorageBufferBind = true;
+        commandBuffer->needFragmentUniformBind = true;
+        commandBuffer->needComputeBufferBind = true;
+        commandBuffer->needComputeTextureBind = true;
+        commandBuffer->needComputeUniformBind = true;
 
-        METAL_INTERNAL_AcquireFence(renderer, command_buffer);
-        command_buffer->autoReleaseFence = 1;
+        METAL_INTERNAL_AcquireFence(renderer, commandBuffer);
+        commandBuffer->autoReleaseFence = 1;
 
         SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
-        return (SDL_GPUCommandBuffer *)command_buffer;
+        return (SDL_GPUCommandBuffer *)commandBuffer;
     }
 }
 
 // This function assumes that it's called from within an autorelease pool
 static MetalUniformBuffer *METAL_INTERNAL_AcquireUniformBufferFromPool(
-    MetalCommandBuffer *command_buffer)
+    MetalCommandBuffer *commandBuffer)
 {
-    MetalRenderer *renderer = command_buffer->renderer;
+    MetalRenderer *renderer = commandBuffer->renderer;
     MetalUniformBuffer *uniformBuffer;
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
@@ -2057,7 +2057,7 @@ static MetalUniformBuffer *METAL_INTERNAL_AcquireUniformBufferFromPool(
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
-    METAL_INTERNAL_TrackUniformBuffer(command_buffer, uniformBuffer);
+    METAL_INTERNAL_TrackUniformBuffer(commandBuffer, uniformBuffer);
 
     return uniformBuffer;
 }
@@ -2081,30 +2081,30 @@ static void METAL_INTERNAL_ReturnUniformBufferToPool(
 }
 
 static void METAL_SetViewport(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUViewport *viewport)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MTLViewport metalViewport;
 
         metalViewport.originX = viewport->x;
         metalViewport.originY = viewport->y;
         metalViewport.width = viewport->w;
         metalViewport.height = viewport->h;
-        metalViewport.znear = viewport->minDepth;
-        metalViewport.zfar = viewport->maxDepth;
+        metalViewport.znear = viewport->min_depth;
+        metalViewport.zfar = viewport->max_depth;
 
         [metalCommandBuffer->renderEncoder setViewport:metalViewport];
     }
 }
 
 static void METAL_SetScissor(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_Rect *scissor)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MTLScissorRect metalScissor;
 
         metalScissor.x = scissor->x;
@@ -2117,36 +2117,36 @@ static void METAL_SetScissor(
 }
 
 static void METAL_SetBlendConstants(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_FColor blend_constants)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_FColor blendConstants)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
-        [metalCommandBuffer->renderEncoder setBlendColorRed:blend_constants.r
-                                                      green:blend_constants.g
-                                                       blue:blend_constants.b
-                                                      alpha:blend_constants.a];
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
+        [metalCommandBuffer->renderEncoder setBlendColorRed:blendConstants.r
+                                                      green:blendConstants.g
+                                                       blue:blendConstants.b
+                                                      alpha:blendConstants.a];
     }
 }
 
 static void METAL_SetStencilReference(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     Uint8 reference)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         [metalCommandBuffer->renderEncoder setStencilReferenceValue:reference];
     }
 }
 
 static void METAL_BeginRenderPass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUColorTargetInfo *color_target_infos,
-    Uint32 num_color_targets,
-    const SDL_GPUDepthStencilTargetInfo *depth_stencil_target_info)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUColorTargetInfo *colorTargetInfos,
+    Uint32 numColorTargets,
+    const SDL_GPUDepthStencilTargetInfo *depthStencilTargetInfo)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalRenderer *renderer = metalCommandBuffer->renderer;
         MTLRenderPassDescriptor *passDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
         Uint32 vpWidth = UINT_MAX;
@@ -2154,12 +2154,12 @@ static void METAL_BeginRenderPass(
         SDL_GPUViewport viewport;
         SDL_Rect scissorRect;
 
-        for (Uint32 i = 0; i < num_color_targets; i += 1) {
-            MetalTextureContainer *container = (MetalTextureContainer *)color_target_infos[i].texture;
+        for (Uint32 i = 0; i < numColorTargets; i += 1) {
+            MetalTextureContainer *container = (MetalTextureContainer *)colorTargetInfos[i].texture;
             MetalTexture *texture = METAL_INTERNAL_PrepareTextureForWrite(
                 renderer,
                 container,
-                color_target_infos[i].cycle);
+                colorTargetInfos[i].cycle);
 
             if (texture->msaaHandle) {
                 passDescriptor.colorAttachments[i].texture = texture->msaaHandle;
@@ -2167,31 +2167,31 @@ static void METAL_BeginRenderPass(
             } else {
                 passDescriptor.colorAttachments[i].texture = texture->handle;
             }
-            passDescriptor.colorAttachments[i].level = color_target_infos[i].mip_level;
+            passDescriptor.colorAttachments[i].level = colorTargetInfos[i].mip_level;
             if (container->header.info.type == SDL_GPU_TEXTURETYPE_3D) {
-                passDescriptor.colorAttachments[i].depthPlane = color_target_infos[i].layer_or_depth_plane;
+                passDescriptor.colorAttachments[i].depthPlane = colorTargetInfos[i].layer_or_depth_plane;
             } else {
-                passDescriptor.colorAttachments[i].slice = color_target_infos[i].layer_or_depth_plane;
+                passDescriptor.colorAttachments[i].slice = colorTargetInfos[i].layer_or_depth_plane;
             }
             passDescriptor.colorAttachments[i].clearColor = MTLClearColorMake(
-                color_target_infos[i].clear_color.r,
-                color_target_infos[i].clear_color.g,
-                color_target_infos[i].clear_color.b,
-                color_target_infos[i].clear_color.a);
-            passDescriptor.colorAttachments[i].loadAction = SDLToMetal_LoadOp[color_target_infos[i].load_op];
+                colorTargetInfos[i].clear_color.r,
+                colorTargetInfos[i].clear_color.g,
+                colorTargetInfos[i].clear_color.b,
+                colorTargetInfos[i].clear_color.a);
+            passDescriptor.colorAttachments[i].loadAction = SDLToMetal_LoadOp[colorTargetInfos[i].load_op];
             passDescriptor.colorAttachments[i].storeAction = SDLToMetal_StoreOp(
-                color_target_infos[i].store_op,
+                colorTargetInfos[i].store_op,
                 texture->msaaHandle ? 1 : 0);
 
             METAL_INTERNAL_TrackTexture(metalCommandBuffer, texture);
         }
 
-        if (depth_stencil_target_info != NULL) {
-            MetalTextureContainer *container = (MetalTextureContainer *)depth_stencil_target_info->texture;
+        if (depthStencilTargetInfo != NULL) {
+            MetalTextureContainer *container = (MetalTextureContainer *)depthStencilTargetInfo->texture;
             MetalTexture *texture = METAL_INTERNAL_PrepareTextureForWrite(
                 renderer,
                 container,
-                depth_stencil_target_info->cycle);
+                depthStencilTargetInfo->cycle);
 
             if (texture->msaaHandle) {
                 passDescriptor.depthAttachment.texture = texture->msaaHandle;
@@ -2199,11 +2199,11 @@ static void METAL_BeginRenderPass(
             } else {
                 passDescriptor.depthAttachment.texture = texture->handle;
             }
-            passDescriptor.depthAttachment.loadAction = SDLToMetal_LoadOp[depth_stencil_target_info->load_op];
+            passDescriptor.depthAttachment.loadAction = SDLToMetal_LoadOp[depthStencilTargetInfo->load_op];
             passDescriptor.depthAttachment.storeAction = SDLToMetal_StoreOp(
-                depth_stencil_target_info->store_op,
+                depthStencilTargetInfo->store_op,
                 texture->msaaHandle ? 1 : 0);
-            passDescriptor.depthAttachment.clearDepth = depth_stencil_target_info->clear_value.depth;
+            passDescriptor.depthAttachment.clearDepth = depthStencilTargetInfo->clear_value.depth;
 
             if (IsStencilFormat(container->header.info.format)) {
                 if (texture->msaaHandle) {
@@ -2212,11 +2212,11 @@ static void METAL_BeginRenderPass(
                 } else {
                     passDescriptor.stencilAttachment.texture = texture->handle;
                 }
-                passDescriptor.stencilAttachment.loadAction = SDLToMetal_LoadOp[depth_stencil_target_info->load_op];
+                passDescriptor.stencilAttachment.loadAction = SDLToMetal_LoadOp[depthStencilTargetInfo->load_op];
                 passDescriptor.stencilAttachment.storeAction = SDLToMetal_StoreOp(
-                    depth_stencil_target_info->store_op,
+                    depthStencilTargetInfo->store_op,
                     texture->msaaHandle ? 1 : 0);
-                passDescriptor.stencilAttachment.clearStencil = depth_stencil_target_info->clear_value.stencil;
+                passDescriptor.stencilAttachment.clearStencil = depthStencilTargetInfo->clear_value.stencil;
             }
 
             METAL_INTERNAL_TrackTexture(metalCommandBuffer, texture);
@@ -2225,10 +2225,10 @@ static void METAL_BeginRenderPass(
         metalCommandBuffer->renderEncoder = [metalCommandBuffer->handle renderCommandEncoderWithDescriptor:passDescriptor];
 
         // The viewport cannot be larger than the smallest target.
-        for (Uint32 i = 0; i < num_color_targets; i += 1) {
-            MetalTextureContainer *container = (MetalTextureContainer *)color_target_infos[i].texture;
-            Uint32 w = container->header.info.width >> color_target_infos[i].mip_level;
-            Uint32 h = container->header.info.height >> color_target_infos[i].mip_level;
+        for (Uint32 i = 0; i < numColorTargets; i += 1) {
+            MetalTextureContainer *container = (MetalTextureContainer *)colorTargetInfos[i].texture;
+            Uint32 w = container->header.info.width >> colorTargetInfos[i].mip_level;
+            Uint32 h = container->header.info.height >> colorTargetInfos[i].mip_level;
 
             if (w < vpWidth) {
                 vpWidth = w;
@@ -2239,8 +2239,8 @@ static void METAL_BeginRenderPass(
             }
         }
 
-        if (depth_stencil_target_info != NULL) {
-            MetalTextureContainer *container = (MetalTextureContainer *)depth_stencil_target_info->texture;
+        if (depthStencilTargetInfo != NULL) {
+            MetalTextureContainer *container = (MetalTextureContainer *)depthStencilTargetInfo->texture;
             Uint32 w = container->header.info.width;
             Uint32 h = container->header.info.height;
 
@@ -2258,43 +2258,43 @@ static void METAL_BeginRenderPass(
         viewport.y = 0;
         viewport.w = vpWidth;
         viewport.h = vpHeight;
-        viewport.minDepth = 0;
-        viewport.maxDepth = 1;
-        METAL_SetViewport(command_buffer, &viewport);
+        viewport.min_depth = 0;
+        viewport.max_depth = 1;
+        METAL_SetViewport(commandBuffer, &viewport);
 
         scissorRect.x = 0;
         scissorRect.y = 0;
         scissorRect.w = vpWidth;
         scissorRect.h = vpHeight;
-        METAL_SetScissor(command_buffer, &scissorRect);
+        METAL_SetScissor(commandBuffer, &scissorRect);
 
         METAL_SetBlendConstants(
-            command_buffer,
+            commandBuffer,
             (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
 
         METAL_SetStencilReference(
-            command_buffer,
+            commandBuffer,
             0);
     }
 }
 
 static void METAL_BindGraphicsPipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
-        MetalGraphicsPipeline *metalGraphicsPipeline = (MetalGraphicsPipeline *)graphics_pipeline;
-        SDL_GPURasterizerState *rast = &metalGraphicsPipeline->rasterizer_state;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
+        MetalGraphicsPipeline *metalGraphicsPipeline = (MetalGraphicsPipeline *)graphicsPipeline;
+        SDL_GPURasterizerState *rast = &metalGraphicsPipeline->rasterizerState;
 
         metalCommandBuffer->graphics_pipeline = metalGraphicsPipeline;
 
         [metalCommandBuffer->renderEncoder setRenderPipelineState:metalGraphicsPipeline->handle];
 
         // Apply rasterizer state
-        [metalCommandBuffer->renderEncoder setTriangleFillMode:SDLToMetal_PolygonMode[metalGraphicsPipeline->rasterizer_state.fill_mode]];
-        [metalCommandBuffer->renderEncoder setCullMode:SDLToMetal_CullMode[metalGraphicsPipeline->rasterizer_state.cull_mode]];
-        [metalCommandBuffer->renderEncoder setFrontFacingWinding:SDLToMetal_FrontFace[metalGraphicsPipeline->rasterizer_state.frontFace]];
+        [metalCommandBuffer->renderEncoder setTriangleFillMode:SDLToMetal_PolygonMode[metalGraphicsPipeline->rasterizerState.fill_mode]];
+        [metalCommandBuffer->renderEncoder setCullMode:SDLToMetal_CullMode[metalGraphicsPipeline->rasterizerState.cull_mode]];
+        [metalCommandBuffer->renderEncoder setFrontFacingWinding:SDLToMetal_FrontFace[metalGraphicsPipeline->rasterizerState.front_face]];
         [metalCommandBuffer->renderEncoder
             setDepthBias:((rast->enable_depth_bias) ? rast->depth_bias_constant_factor : 0)
               slopeScale:((rast->enable_depth_bias) ? rast->depth_bias_slope_factor : 0)
@@ -2326,16 +2326,16 @@ static void METAL_BindGraphicsPipeline(
 }
 
 static void METAL_BindVertexBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_binding,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstBinding,
     const SDL_GPUBufferBinding *bindings,
-    Uint32 num_bindings)
+    Uint32 numBindings)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         id<MTLBuffer> metalBuffers[MAX_BUFFER_BINDINGS];
         NSUInteger bufferOffsets[MAX_BUFFER_BINDINGS];
-        NSRange range = NSMakeRange(METAL_INTERNAL_GetVertexBufferIndex(first_binding), num_bindings);
+        NSRange range = NSMakeRange(METAL_INTERNAL_GetVertexBufferIndex(firstBinding), numBindings);
 
         if (range.length == 0) {
             return;
@@ -2354,38 +2354,38 @@ static void METAL_BindVertexBuffers(
 }
 
 static void METAL_BindIndexBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferBinding *binding,
-    SDL_GPUIndexElementSize index_element_size)
+    SDL_GPUIndexElementSize indexElementSize)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     metalCommandBuffer->indexBuffer = ((MetalBufferContainer *)binding->buffer)->activeBuffer;
     metalCommandBuffer->indexBufferOffset = binding->offset;
-    metalCommandBuffer->index_element_size = index_element_size;
+    metalCommandBuffer->index_element_size = indexElementSize;
 
     METAL_INTERNAL_TrackBuffer(metalCommandBuffer, metalCommandBuffer->indexBuffer);
 }
 
 static void METAL_BindVertexSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalTextureContainer *textureContainer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        textureContainer = (MetalTextureContainer *)texture_sampler_bindings[i].texture;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        textureContainer = (MetalTextureContainer *)textureSamplerBindings[i].texture;
 
         METAL_INTERNAL_TrackTexture(
             metalCommandBuffer,
             textureContainer->activeTexture);
 
-        metalCommandBuffer->vertexSamplers[first_slot + i] =
-            ((MetalSampler *)texture_sampler_bindings[i].sampler)->handle;
+        metalCommandBuffer->vertexSamplers[firstSlot + i] =
+            ((MetalSampler *)textureSamplerBindings[i].sampler)->handle;
 
-        metalCommandBuffer->vertexTextures[first_slot + i] =
+        metalCommandBuffer->vertexTextures[firstSlot + i] =
             textureContainer->activeTexture->handle;
     }
 
@@ -2393,22 +2393,22 @@ static void METAL_BindVertexSamplers(
 }
 
 static void METAL_BindVertexStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalTextureContainer *textureContainer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        textureContainer = (MetalTextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        textureContainer = (MetalTextureContainer *)storageTextures[i];
 
         METAL_INTERNAL_TrackTexture(
             metalCommandBuffer,
             textureContainer->activeTexture);
 
-        metalCommandBuffer->vertexStorageTextures[first_slot + i] =
+        metalCommandBuffer->vertexStorageTextures[firstSlot + i] =
             textureContainer->activeTexture->handle;
     }
 
@@ -2416,22 +2416,22 @@ static void METAL_BindVertexStorageTextures(
 }
 
 static void METAL_BindVertexStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalBufferContainer *bufferContainer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (MetalBufferContainer *)storage_buffers[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        bufferContainer = (MetalBufferContainer *)storageBuffers[i];
 
         METAL_INTERNAL_TrackBuffer(
             metalCommandBuffer,
             bufferContainer->activeBuffer);
 
-        metalCommandBuffer->vertexStorageBuffers[first_slot + i] =
+        metalCommandBuffer->vertexStorageBuffers[firstSlot + i] =
             bufferContainer->activeBuffer->handle;
     }
 
@@ -2439,25 +2439,25 @@ static void METAL_BindVertexStorageBuffers(
 }
 
 static void METAL_BindFragmentSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalTextureContainer *textureContainer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        textureContainer = (MetalTextureContainer *)texture_sampler_bindings[i].texture;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        textureContainer = (MetalTextureContainer *)textureSamplerBindings[i].texture;
 
         METAL_INTERNAL_TrackTexture(
             metalCommandBuffer,
             textureContainer->activeTexture);
 
-        metalCommandBuffer->fragmentSamplers[first_slot + i] =
-            ((MetalSampler *)texture_sampler_bindings[i].sampler)->handle;
+        metalCommandBuffer->fragmentSamplers[firstSlot + i] =
+            ((MetalSampler *)textureSamplerBindings[i].sampler)->handle;
 
-        metalCommandBuffer->fragmentTextures[first_slot + i] =
+        metalCommandBuffer->fragmentTextures[firstSlot + i] =
             textureContainer->activeTexture->handle;
     }
 
@@ -2465,22 +2465,22 @@ static void METAL_BindFragmentSamplers(
 }
 
 static void METAL_BindFragmentStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalTextureContainer *textureContainer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        textureContainer = (MetalTextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        textureContainer = (MetalTextureContainer *)storageTextures[i];
 
         METAL_INTERNAL_TrackTexture(
             metalCommandBuffer,
             textureContainer->activeTexture);
 
-        metalCommandBuffer->fragmentStorageTextures[first_slot + i] =
+        metalCommandBuffer->fragmentStorageTextures[firstSlot + i] =
             textureContainer->activeTexture->handle;
     }
 
@@ -2488,22 +2488,22 @@ static void METAL_BindFragmentStorageTextures(
 }
 
 static void METAL_BindFragmentStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalBufferContainer *bufferContainer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (MetalBufferContainer *)storage_buffers[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        bufferContainer = (MetalBufferContainer *)storageBuffers[i];
 
         METAL_INTERNAL_TrackBuffer(
             metalCommandBuffer,
             bufferContainer->activeBuffer);
 
-        metalCommandBuffer->fragmentStorageBuffers[first_slot + i] =
+        metalCommandBuffer->fragmentStorageBuffers[firstSlot + i] =
             bufferContainer->activeBuffer->handle;
     }
 
@@ -2512,218 +2512,218 @@ static void METAL_BindFragmentStorageBuffers(
 
 // This function assumes that it's called from within an autorelease pool
 static void METAL_INTERNAL_BindGraphicsResources(
-    MetalCommandBuffer *command_buffer)
+    MetalCommandBuffer *commandBuffer)
 {
-    MetalGraphicsPipeline *graphics_pipeline = command_buffer->graphics_pipeline;
+    MetalGraphicsPipeline *graphicsPipeline = commandBuffer->graphics_pipeline;
     NSUInteger offsets[MAX_STORAGE_BUFFERS_PER_STAGE] = { 0 };
 
     // Vertex Samplers+Textures
 
-    if (graphics_pipeline->vertexSamplerCount > 0 && command_buffer->needVertexSamplerBind) {
-        [command_buffer->renderEncoder setVertexSamplerStates:command_buffer->vertexSamplers
-                                                    withRange:NSMakeRange(0, graphics_pipeline->vertexSamplerCount)];
-        [command_buffer->renderEncoder setVertexTextures:command_buffer->vertexTextures
-                                               withRange:NSMakeRange(0, graphics_pipeline->vertexSamplerCount)];
-        command_buffer->needVertexSamplerBind = false;
+    if (graphicsPipeline->vertexSamplerCount > 0 && commandBuffer->needVertexSamplerBind) {
+        [commandBuffer->renderEncoder setVertexSamplerStates:commandBuffer->vertexSamplers
+                                                   withRange:NSMakeRange(0, graphicsPipeline->vertexSamplerCount)];
+        [commandBuffer->renderEncoder setVertexTextures:commandBuffer->vertexTextures
+                                              withRange:NSMakeRange(0, graphicsPipeline->vertexSamplerCount)];
+        commandBuffer->needVertexSamplerBind = false;
     }
 
     // Vertex Storage Textures
 
-    if (graphics_pipeline->vertexStorageTextureCount > 0 && command_buffer->needVertexStorageTextureBind) {
-        [command_buffer->renderEncoder setVertexTextures:command_buffer->vertexStorageTextures
-                                               withRange:NSMakeRange(graphics_pipeline->vertexSamplerCount,
-                                                                     graphics_pipeline->vertexStorageTextureCount)];
-        command_buffer->needVertexStorageTextureBind = false;
+    if (graphicsPipeline->vertexStorageTextureCount > 0 && commandBuffer->needVertexStorageTextureBind) {
+        [commandBuffer->renderEncoder setVertexTextures:commandBuffer->vertexStorageTextures
+                                              withRange:NSMakeRange(graphicsPipeline->vertexSamplerCount,
+                                                                    graphicsPipeline->vertexStorageTextureCount)];
+        commandBuffer->needVertexStorageTextureBind = false;
     }
 
     // Vertex Storage Buffers
 
-    if (graphics_pipeline->vertexStorageBufferCount > 0 && command_buffer->needVertexStorageBufferBind) {
-        [command_buffer->renderEncoder setVertexBuffers:command_buffer->vertexStorageBuffers
-                                                offsets:offsets
-                                              withRange:NSMakeRange(graphics_pipeline->vertexUniformBufferCount,
-                                                                    graphics_pipeline->vertexStorageBufferCount)];
-        command_buffer->needVertexStorageBufferBind = false;
+    if (graphicsPipeline->vertexStorageBufferCount > 0 && commandBuffer->needVertexStorageBufferBind) {
+        [commandBuffer->renderEncoder setVertexBuffers:commandBuffer->vertexStorageBuffers
+                                               offsets:offsets
+                                             withRange:NSMakeRange(graphicsPipeline->vertexUniformBufferCount,
+                                                                   graphicsPipeline->vertexStorageBufferCount)];
+        commandBuffer->needVertexStorageBufferBind = false;
     }
 
     // Vertex Uniform Buffers
 
-    if (graphics_pipeline->vertexUniformBufferCount > 0 && command_buffer->needVertexUniformBind) {
-        for (Uint32 i = 0; i < graphics_pipeline->vertexUniformBufferCount; i += 1) {
-            [command_buffer->renderEncoder
-                setVertexBuffer:command_buffer->vertexUniformBuffers[i]->handle
-                         offset:command_buffer->vertexUniformBuffers[i]->drawOffset
+    if (graphicsPipeline->vertexUniformBufferCount > 0 && commandBuffer->needVertexUniformBind) {
+        for (Uint32 i = 0; i < graphicsPipeline->vertexUniformBufferCount; i += 1) {
+            [commandBuffer->renderEncoder
+                setVertexBuffer:commandBuffer->vertexUniformBuffers[i]->handle
+                         offset:commandBuffer->vertexUniformBuffers[i]->drawOffset
                         atIndex:i];
         }
-        command_buffer->needVertexUniformBind = false;
+        commandBuffer->needVertexUniformBind = false;
     }
 
     // Fragment Samplers+Textures
 
-    if (graphics_pipeline->fragmentSamplerCount > 0 && command_buffer->needFragmentSamplerBind) {
-        [command_buffer->renderEncoder setFragmentSamplerStates:command_buffer->fragmentSamplers
-                                                      withRange:NSMakeRange(0, graphics_pipeline->fragmentSamplerCount)];
-        [command_buffer->renderEncoder setFragmentTextures:command_buffer->fragmentTextures
-                                                 withRange:NSMakeRange(0, graphics_pipeline->fragmentSamplerCount)];
-        command_buffer->needFragmentSamplerBind = false;
+    if (graphicsPipeline->fragmentSamplerCount > 0 && commandBuffer->needFragmentSamplerBind) {
+        [commandBuffer->renderEncoder setFragmentSamplerStates:commandBuffer->fragmentSamplers
+                                                     withRange:NSMakeRange(0, graphicsPipeline->fragmentSamplerCount)];
+        [commandBuffer->renderEncoder setFragmentTextures:commandBuffer->fragmentTextures
+                                                withRange:NSMakeRange(0, graphicsPipeline->fragmentSamplerCount)];
+        commandBuffer->needFragmentSamplerBind = false;
     }
 
     // Fragment Storage Textures
 
-    if (graphics_pipeline->fragmentStorageTextureCount > 0 && command_buffer->needFragmentStorageTextureBind) {
-        [command_buffer->renderEncoder setFragmentTextures:command_buffer->fragmentStorageTextures
-                                                 withRange:NSMakeRange(graphics_pipeline->fragmentSamplerCount,
-                                                                       graphics_pipeline->fragmentStorageTextureCount)];
-        command_buffer->needFragmentStorageTextureBind = false;
+    if (graphicsPipeline->fragmentStorageTextureCount > 0 && commandBuffer->needFragmentStorageTextureBind) {
+        [commandBuffer->renderEncoder setFragmentTextures:commandBuffer->fragmentStorageTextures
+                                                withRange:NSMakeRange(graphicsPipeline->fragmentSamplerCount,
+                                                                      graphicsPipeline->fragmentStorageTextureCount)];
+        commandBuffer->needFragmentStorageTextureBind = false;
     }
 
     // Fragment Storage Buffers
 
-    if (graphics_pipeline->fragmentStorageBufferCount > 0 && command_buffer->needFragmentStorageBufferBind) {
-        [command_buffer->renderEncoder setFragmentBuffers:command_buffer->fragmentStorageBuffers
-                                                  offsets:offsets
-                                                withRange:NSMakeRange(graphics_pipeline->fragmentUniformBufferCount,
-                                                                      graphics_pipeline->fragmentStorageBufferCount)];
-        command_buffer->needFragmentStorageBufferBind = false;
+    if (graphicsPipeline->fragmentStorageBufferCount > 0 && commandBuffer->needFragmentStorageBufferBind) {
+        [commandBuffer->renderEncoder setFragmentBuffers:commandBuffer->fragmentStorageBuffers
+                                                 offsets:offsets
+                                               withRange:NSMakeRange(graphicsPipeline->fragmentUniformBufferCount,
+                                                                     graphicsPipeline->fragmentStorageBufferCount)];
+        commandBuffer->needFragmentStorageBufferBind = false;
     }
 
     // Fragment Uniform Buffers
-    if (graphics_pipeline->fragmentUniformBufferCount > 0 && command_buffer->needFragmentUniformBind) {
-        for (Uint32 i = 0; i < graphics_pipeline->fragmentUniformBufferCount; i += 1) {
-            [command_buffer->renderEncoder
-                setFragmentBuffer:command_buffer->fragmentUniformBuffers[i]->handle
-                           offset:command_buffer->fragmentUniformBuffers[i]->drawOffset
+    if (graphicsPipeline->fragmentUniformBufferCount > 0 && commandBuffer->needFragmentUniformBind) {
+        for (Uint32 i = 0; i < graphicsPipeline->fragmentUniformBufferCount; i += 1) {
+            [commandBuffer->renderEncoder
+                setFragmentBuffer:commandBuffer->fragmentUniformBuffers[i]->handle
+                           offset:commandBuffer->fragmentUniformBuffers[i]->drawOffset
                           atIndex:i];
         }
-        command_buffer->needFragmentUniformBind = false;
+        commandBuffer->needFragmentUniformBind = false;
     }
 }
 
 // This function assumes that it's called from within an autorelease pool
 static void METAL_INTERNAL_BindComputeResources(
-    MetalCommandBuffer *command_buffer)
+    MetalCommandBuffer *commandBuffer)
 {
-    MetalComputePipeline *compute_pipeline = command_buffer->compute_pipeline;
+    MetalComputePipeline *computePipeline = commandBuffer->compute_pipeline;
     NSUInteger offsets[MAX_STORAGE_BUFFERS_PER_STAGE] = { 0 }; // 8 is the max for both read and write-only
 
-    if (command_buffer->needComputeTextureBind) {
+    if (commandBuffer->needComputeTextureBind) {
         // Bind read-only textures
-        if (compute_pipeline->num_readonly_storage_textures > 0) {
-            [command_buffer->computeEncoder setTextures:command_buffer->computeReadOnlyTextures
-                                              withRange:NSMakeRange(0, compute_pipeline->num_readonly_storage_textures)];
+        if (computePipeline->num_readonly_storage_textures > 0) {
+            [commandBuffer->computeEncoder setTextures:commandBuffer->computeReadOnlyTextures
+                                             withRange:NSMakeRange(0, computePipeline->num_readonly_storage_textures)];
         }
 
         // Bind write-only textures
-        if (compute_pipeline->num_writeonly_storage_textures > 0) {
-            [command_buffer->computeEncoder setTextures:command_buffer->computeWriteOnlyTextures
-                                              withRange:NSMakeRange(
-                                                            compute_pipeline->num_readonly_storage_textures,
-                                                            compute_pipeline->num_writeonly_storage_textures)];
+        if (computePipeline->num_writeonly_storage_textures > 0) {
+            [commandBuffer->computeEncoder setTextures:commandBuffer->computeWriteOnlyTextures
+                                             withRange:NSMakeRange(
+                                                           computePipeline->num_readonly_storage_textures,
+                                                           computePipeline->num_writeonly_storage_textures)];
         }
-        command_buffer->needComputeTextureBind = false;
+        commandBuffer->needComputeTextureBind = false;
     }
 
-    if (command_buffer->needComputeBufferBind) {
+    if (commandBuffer->needComputeBufferBind) {
         // Bind read-only buffers
-        if (compute_pipeline->num_readonly_storage_buffers > 0) {
-            [command_buffer->computeEncoder setBuffers:command_buffer->computeReadOnlyBuffers
-                                               offsets:offsets
-                                             withRange:NSMakeRange(compute_pipeline->num_uniform_buffers,
-                                                                   compute_pipeline->num_readonly_storage_buffers)];
+        if (computePipeline->num_readonly_storage_buffers > 0) {
+            [commandBuffer->computeEncoder setBuffers:commandBuffer->computeReadOnlyBuffers
+                                              offsets:offsets
+                                            withRange:NSMakeRange(computePipeline->numUniformBuffers,
+                                                                  computePipeline->num_readonly_storage_buffers)];
         }
         // Bind write-only buffers
-        if (compute_pipeline->num_writeonly_storage_buffers > 0) {
-            [command_buffer->computeEncoder setBuffers:command_buffer->computeWriteOnlyBuffers
-                                               offsets:offsets
-                                             withRange:NSMakeRange(
-                                                           compute_pipeline->num_uniform_buffers +
-                                                               compute_pipeline->num_readonly_storage_buffers,
-                                                           compute_pipeline->num_writeonly_storage_buffers)];
+        if (computePipeline->num_writeonly_storage_buffers > 0) {
+            [commandBuffer->computeEncoder setBuffers:commandBuffer->computeWriteOnlyBuffers
+                                              offsets:offsets
+                                            withRange:NSMakeRange(
+                                                          computePipeline->numUniformBuffers +
+                                                              computePipeline->num_readonly_storage_buffers,
+                                                          computePipeline->num_writeonly_storage_buffers)];
         }
-        command_buffer->needComputeBufferBind = false;
+        commandBuffer->needComputeBufferBind = false;
     }
 
-    if (command_buffer->needComputeUniformBind) {
-        for (Uint32 i = 0; i < compute_pipeline->num_uniform_buffers; i += 1) {
-            [command_buffer->computeEncoder
-                setBuffer:command_buffer->computeUniformBuffers[i]->handle
-                   offset:command_buffer->computeUniformBuffers[i]->drawOffset
+    if (commandBuffer->needComputeUniformBind) {
+        for (Uint32 i = 0; i < computePipeline->numUniformBuffers; i += 1) {
+            [commandBuffer->computeEncoder
+                setBuffer:commandBuffer->computeUniformBuffers[i]->handle
+                   offset:commandBuffer->computeUniformBuffers[i]->drawOffset
                   atIndex:i];
         }
 
-        command_buffer->needComputeUniformBind = false;
+        commandBuffer->needComputeUniformBind = false;
     }
 }
 
 static void METAL_DrawIndexedPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_indices,
-    Uint32 num_instances,
-    Uint32 first_index,
-    Sint32 vertex_offset,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numIndices,
+    Uint32 numInstances,
+    Uint32 firstIndex,
+    Sint32 vertexOffset,
+    Uint32 firstInstance)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
-        SDL_GPUPrimitiveType primitive_type = metalCommandBuffer->graphics_pipeline->primitive_type;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
+        SDL_GPUPrimitiveType primitiveType = metalCommandBuffer->graphics_pipeline->primitiveType;
         Uint32 indexSize = IndexSize(metalCommandBuffer->index_element_size);
 
         METAL_INTERNAL_BindGraphicsResources(metalCommandBuffer);
 
         [metalCommandBuffer->renderEncoder
-            drawIndexedPrimitives:SDLToMetal_PrimitiveType[primitive_type]
-                       indexCount:num_indices
+            drawIndexedPrimitives:SDLToMetal_PrimitiveType[primitiveType]
+                       indexCount:numIndices
                         indexType:SDLToMetal_IndexType[metalCommandBuffer->index_element_size]
                       indexBuffer:metalCommandBuffer->indexBuffer->handle
-                indexBufferOffset:metalCommandBuffer->indexBufferOffset + (first_index * indexSize)
-                    instanceCount:num_instances
-                       baseVertex:vertex_offset
-                     baseInstance:first_instance];
+                indexBufferOffset:metalCommandBuffer->indexBufferOffset + (firstIndex * indexSize)
+                    instanceCount:numInstances
+                       baseVertex:vertexOffset
+                     baseInstance:firstInstance];
     }
 }
 
 static void METAL_DrawPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_vertices,
-    Uint32 num_instances,
-    Uint32 first_vertex,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numVertices,
+    Uint32 numInstances,
+    Uint32 firstVertex,
+    Uint32 firstInstance)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
-        SDL_GPUPrimitiveType primitive_type = metalCommandBuffer->graphics_pipeline->primitive_type;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
+        SDL_GPUPrimitiveType primitiveType = metalCommandBuffer->graphics_pipeline->primitiveType;
 
         METAL_INTERNAL_BindGraphicsResources(metalCommandBuffer);
 
         [metalCommandBuffer->renderEncoder
-            drawPrimitives:SDLToMetal_PrimitiveType[primitive_type]
-               vertexStart:first_vertex
-               vertexCount:num_vertices
-             instanceCount:num_instances
-              baseInstance:first_instance];
+            drawPrimitives:SDLToMetal_PrimitiveType[primitiveType]
+               vertexStart:firstVertex
+               vertexCount:numVertices
+             instanceCount:numInstances
+              baseInstance:firstInstance];
     }
 }
 
 static void METAL_DrawPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalBuffer *metalBuffer = ((MetalBufferContainer *)buffer)->activeBuffer;
-        SDL_GPUPrimitiveType primitive_type = metalCommandBuffer->graphics_pipeline->primitive_type;
+        SDL_GPUPrimitiveType primitiveType = metalCommandBuffer->graphics_pipeline->primitiveType;
 
         METAL_INTERNAL_BindGraphicsResources(metalCommandBuffer);
 
         /* Metal: "We have multi-draw at home!"
          * Multi-draw at home:
          */
-        for (Uint32 i = 0; i < draw_count; i += 1) {
+        for (Uint32 i = 0; i < drawCount; i += 1) {
             [metalCommandBuffer->renderEncoder
-                      drawPrimitives:SDLToMetal_PrimitiveType[primitive_type]
+                      drawPrimitives:SDLToMetal_PrimitiveType[primitiveType]
                       indirectBuffer:metalBuffer->handle
                 indirectBufferOffset:offset + (pitch * i)];
         }
@@ -2733,22 +2733,22 @@ static void METAL_DrawPrimitivesIndirect(
 }
 
 static void METAL_DrawIndexedPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalBuffer *metalBuffer = ((MetalBufferContainer *)buffer)->activeBuffer;
-        SDL_GPUPrimitiveType primitive_type = metalCommandBuffer->graphics_pipeline->primitive_type;
+        SDL_GPUPrimitiveType primitiveType = metalCommandBuffer->graphics_pipeline->primitiveType;
 
         METAL_INTERNAL_BindGraphicsResources(metalCommandBuffer);
 
-        for (Uint32 i = 0; i < draw_count; i += 1) {
+        for (Uint32 i = 0; i < drawCount; i += 1) {
             [metalCommandBuffer->renderEncoder
-                drawIndexedPrimitives:SDLToMetal_PrimitiveType[primitive_type]
+                drawIndexedPrimitives:SDLToMetal_PrimitiveType[primitiveType]
                             indexType:SDLToMetal_IndexType[metalCommandBuffer->index_element_size]
                           indexBuffer:metalCommandBuffer->indexBuffer->handle
                     indexBufferOffset:metalCommandBuffer->indexBufferOffset
@@ -2761,10 +2761,10 @@ static void METAL_DrawIndexedPrimitivesIndirect(
 }
 
 static void METAL_EndRenderPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         [metalCommandBuffer->renderEncoder endEncoding];
         metalCommandBuffer->renderEncoder = nil;
 
@@ -2789,7 +2789,7 @@ static void METAL_EndRenderPass(
 static void METAL_INTERNAL_PushUniformData(
     MetalCommandBuffer *metalCommandBuffer,
     SDL_GPUShaderStage shaderStage,
-    Uint32 slot_index,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
@@ -2797,23 +2797,23 @@ static void METAL_INTERNAL_PushUniformData(
     Uint32 alignedDataLength;
 
     if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-        if (metalCommandBuffer->vertexUniformBuffers[slot_index] == NULL) {
-            metalCommandBuffer->vertexUniformBuffers[slot_index] = METAL_INTERNAL_AcquireUniformBufferFromPool(
+        if (metalCommandBuffer->vertexUniformBuffers[slotIndex] == NULL) {
+            metalCommandBuffer->vertexUniformBuffers[slotIndex] = METAL_INTERNAL_AcquireUniformBufferFromPool(
                 metalCommandBuffer);
         }
-        metalUniformBuffer = metalCommandBuffer->vertexUniformBuffers[slot_index];
+        metalUniformBuffer = metalCommandBuffer->vertexUniformBuffers[slotIndex];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-        if (metalCommandBuffer->fragmentUniformBuffers[slot_index] == NULL) {
-            metalCommandBuffer->fragmentUniformBuffers[slot_index] = METAL_INTERNAL_AcquireUniformBufferFromPool(
+        if (metalCommandBuffer->fragmentUniformBuffers[slotIndex] == NULL) {
+            metalCommandBuffer->fragmentUniformBuffers[slotIndex] = METAL_INTERNAL_AcquireUniformBufferFromPool(
                 metalCommandBuffer);
         }
-        metalUniformBuffer = metalCommandBuffer->fragmentUniformBuffers[slot_index];
+        metalUniformBuffer = metalCommandBuffer->fragmentUniformBuffers[slotIndex];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-        if (metalCommandBuffer->computeUniformBuffers[slot_index] == NULL) {
-            metalCommandBuffer->computeUniformBuffers[slot_index] = METAL_INTERNAL_AcquireUniformBufferFromPool(
+        if (metalCommandBuffer->computeUniformBuffers[slotIndex] == NULL) {
+            metalCommandBuffer->computeUniformBuffers[slotIndex] = METAL_INTERNAL_AcquireUniformBufferFromPool(
                 metalCommandBuffer);
         }
-        metalUniformBuffer = metalCommandBuffer->computeUniformBuffers[slot_index];
+        metalUniformBuffer = metalCommandBuffer->computeUniformBuffers[slotIndex];
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -2831,11 +2831,11 @@ static void METAL_INTERNAL_PushUniformData(
         metalUniformBuffer->drawOffset = 0;
 
         if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-            metalCommandBuffer->vertexUniformBuffers[slot_index] = metalUniformBuffer;
+            metalCommandBuffer->vertexUniformBuffers[slotIndex] = metalUniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-            metalCommandBuffer->fragmentUniformBuffers[slot_index] = metalUniformBuffer;
+            metalCommandBuffer->fragmentUniformBuffers[slotIndex] = metalUniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-            metalCommandBuffer->computeUniformBuffers[slot_index] = metalUniformBuffer;
+            metalCommandBuffer->computeUniformBuffers[slotIndex] = metalUniformBuffer;
         } else {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
             return;
@@ -2863,32 +2863,32 @@ static void METAL_INTERNAL_PushUniformData(
 }
 
 static void METAL_PushVertexUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     @autoreleasepool {
         METAL_INTERNAL_PushUniformData(
-            (MetalCommandBuffer *)command_buffer,
+            (MetalCommandBuffer *)commandBuffer,
             SDL_GPU_SHADERSTAGE_VERTEX,
-            slot_index,
+            slotIndex,
             data,
             length);
     }
 }
 
 static void METAL_PushFragmentUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     @autoreleasepool {
         METAL_INTERNAL_PushUniformData(
-            (MetalCommandBuffer *)command_buffer,
+            (MetalCommandBuffer *)commandBuffer,
             SDL_GPU_SHADERSTAGE_FRAGMENT,
-            slot_index,
+            slotIndex,
             data,
             length);
     }
@@ -2897,21 +2897,21 @@ static void METAL_PushFragmentUniformData(
 // Blit
 
 static void METAL_Blit(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flip_mode,
+    SDL_FlipMode flipMode,
     SDL_GPUFilter filter,
     bool cycle)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalRenderer *renderer = (MetalRenderer *)metalCommandBuffer->renderer;
 
     SDL_GPU_BlitCommon(
-        command_buffer,
+        commandBuffer,
         source,
         destination,
-        flip_mode,
+        flipMode,
         filter,
         cycle,
         renderer->blitLinearSampler,
@@ -2929,14 +2929,14 @@ static void METAL_Blit(
 // Compute State
 
 static void METAL_BeginComputePass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
-    Uint32 num_storage_texture_bindings,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
-    Uint32 num_storage_buffer_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
+    Uint32 numStorageTextureBindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
+    Uint32 numStorageBufferBindings)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalTextureContainer *textureContainer;
         MetalTexture *texture;
         id<MTLTexture> textureView;
@@ -2945,32 +2945,32 @@ static void METAL_BeginComputePass(
 
         metalCommandBuffer->computeEncoder = [metalCommandBuffer->handle computeCommandEncoder];
 
-        for (Uint32 i = 0; i < num_storage_texture_bindings; i += 1) {
-            textureContainer = (MetalTextureContainer *)storage_texture_bindings[i].texture;
+        for (Uint32 i = 0; i < numStorageTextureBindings; i += 1) {
+            textureContainer = (MetalTextureContainer *)storageTextureBindings[i].texture;
 
             texture = METAL_INTERNAL_PrepareTextureForWrite(
                 metalCommandBuffer->renderer,
                 textureContainer,
-                storage_texture_bindings[i].cycle);
+                storageTextureBindings[i].cycle);
 
             METAL_INTERNAL_TrackTexture(metalCommandBuffer, texture);
 
             textureView = [texture->handle newTextureViewWithPixelFormat:SDLToMetal_SurfaceFormat[textureContainer->header.info.format]
                                                              textureType:SDLToMetal_TextureType[textureContainer->header.info.type]
-                                                                  levels:NSMakeRange(storage_texture_bindings[i].mip_level, 1)
-                                                                  slices:NSMakeRange(storage_texture_bindings[i].layer, 1)];
+                                                                  levels:NSMakeRange(storageTextureBindings[i].mip_level, 1)
+                                                                  slices:NSMakeRange(storageTextureBindings[i].layer, 1)];
 
             metalCommandBuffer->computeWriteOnlyTextures[i] = textureView;
             metalCommandBuffer->needComputeTextureBind = true;
         }
 
-        for (Uint32 i = 0; i < num_storage_buffer_bindings; i += 1) {
-            bufferContainer = (MetalBufferContainer *)storage_buffer_bindings[i].buffer;
+        for (Uint32 i = 0; i < numStorageBufferBindings; i += 1) {
+            bufferContainer = (MetalBufferContainer *)storageBufferBindings[i].buffer;
 
             buffer = METAL_INTERNAL_PrepareBufferForWrite(
                 metalCommandBuffer->renderer,
                 bufferContainer,
-                storage_buffer_bindings[i].cycle);
+                storageBufferBindings[i].cycle);
 
             METAL_INTERNAL_TrackBuffer(
                 metalCommandBuffer,
@@ -2983,18 +2983,18 @@ static void METAL_BeginComputePass(
 }
 
 static void METAL_BindComputePipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUComputePipeline *computePipeline)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
-        MetalComputePipeline *pipeline = (MetalComputePipeline *)compute_pipeline;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
+        MetalComputePipeline *pipeline = (MetalComputePipeline *)computePipeline;
 
         metalCommandBuffer->compute_pipeline = pipeline;
 
         [metalCommandBuffer->computeEncoder setComputePipelineState:pipeline->handle];
 
-        for (Uint32 i = 0; i < pipeline->num_uniform_buffers; i += 1) {
+        for (Uint32 i = 0; i < pipeline->numUniformBuffers; i += 1) {
             if (metalCommandBuffer->computeUniformBuffers[i] == NULL) {
                 metalCommandBuffer->computeUniformBuffers[i] = METAL_INTERNAL_AcquireUniformBufferFromPool(
                     metalCommandBuffer);
@@ -3006,22 +3006,22 @@ static void METAL_BindComputePipeline(
 }
 
 static void METAL_BindComputeStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalTextureContainer *textureContainer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        textureContainer = (MetalTextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        textureContainer = (MetalTextureContainer *)storageTextures[i];
 
         METAL_INTERNAL_TrackTexture(
             metalCommandBuffer,
             textureContainer->activeTexture);
 
-        metalCommandBuffer->computeReadOnlyTextures[first_slot + i] =
+        metalCommandBuffer->computeReadOnlyTextures[firstSlot + i] =
             textureContainer->activeTexture->handle;
     }
 
@@ -3029,22 +3029,22 @@ static void METAL_BindComputeStorageTextures(
 }
 
 static void METAL_BindComputeStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalBufferContainer *bufferContainer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (MetalBufferContainer *)storage_buffers[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        bufferContainer = (MetalBufferContainer *)storageBuffers[i];
 
         METAL_INTERNAL_TrackBuffer(
             metalCommandBuffer,
             bufferContainer->activeBuffer);
 
-        metalCommandBuffer->computeReadOnlyBuffers[first_slot + i] =
+        metalCommandBuffer->computeReadOnlyBuffers[firstSlot + i] =
             bufferContainer->activeBuffer->handle;
     }
 
@@ -3052,30 +3052,30 @@ static void METAL_BindComputeStorageBuffers(
 }
 
 static void METAL_PushComputeUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     @autoreleasepool {
         METAL_INTERNAL_PushUniformData(
-            (MetalCommandBuffer *)command_buffer,
+            (MetalCommandBuffer *)commandBuffer,
             SDL_GPU_SHADERSTAGE_COMPUTE,
-            slot_index,
+            slotIndex,
             data,
             length);
     }
 }
 
 static void METAL_DispatchCompute(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 groupcount_x,
-    Uint32 groupcount_y,
-    Uint32 groupcount_z)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 groupcountX,
+    Uint32 groupcountY,
+    Uint32 groupcountZ)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
-        MTLSize threadgroups = MTLSizeMake(groupcount_x, groupcount_y, groupcount_z);
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
+        MTLSize threadgroups = MTLSizeMake(groupcountX, groupcountY, groupcountZ);
         MTLSize threadsPerThreadgroup = MTLSizeMake(
             metalCommandBuffer->compute_pipeline->threadcount_x,
             metalCommandBuffer->compute_pipeline->threadcount_y,
@@ -3090,12 +3090,12 @@ static void METAL_DispatchCompute(
 }
 
 static void METAL_DispatchComputeIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalBuffer *metalBuffer = ((MetalBufferContainer *)buffer)->activeBuffer;
         MTLSize threadsPerThreadgroup = MTLSizeMake(
             metalCommandBuffer->compute_pipeline->threadcount_x,
@@ -3114,10 +3114,10 @@ static void METAL_DispatchComputeIndirect(
 }
 
 static void METAL_EndComputePass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         [metalCommandBuffer->computeEncoder endEncoding];
         metalCommandBuffer->computeEncoder = nil;
 
@@ -3170,67 +3170,67 @@ static void METAL_ReleaseFence(
 
 static void METAL_INTERNAL_CleanCommandBuffer(
     MetalRenderer *renderer,
-    MetalCommandBuffer *command_buffer)
+    MetalCommandBuffer *commandBuffer)
 {
     Uint32 i;
 
     // Reference Counting
-    for (i = 0; i < command_buffer->usedBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedBuffers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedBuffers[i]->referenceCount);
     }
-    command_buffer->usedBufferCount = 0;
+    commandBuffer->usedBufferCount = 0;
 
-    for (i = 0; i < command_buffer->usedTextureCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedTextures[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedTextureCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedTextures[i]->referenceCount);
     }
-    command_buffer->usedTextureCount = 0;
+    commandBuffer->usedTextureCount = 0;
 
     // Uniform buffers are now available
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
 
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
         METAL_INTERNAL_ReturnUniformBufferToPool(
             renderer,
-            command_buffer->usedUniformBuffers[i]);
+            commandBuffer->usedUniformBuffers[i]);
     }
-    command_buffer->usedUniformBufferCount = 0;
+    commandBuffer->usedUniformBufferCount = 0;
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
     // Reset presentation
-    command_buffer->windowDataCount = 0;
+    commandBuffer->windowDataCount = 0;
 
     // Reset bindings
-    command_buffer->indexBuffer = NULL;
+    commandBuffer->indexBuffer = NULL;
     for (i = 0; i < MAX_TEXTURE_SAMPLERS_PER_STAGE; i += 1) {
-        command_buffer->vertexSamplers[i] = nil;
-        command_buffer->vertexTextures[i] = nil;
-        command_buffer->fragmentSamplers[i] = nil;
-        command_buffer->fragmentTextures[i] = nil;
+        commandBuffer->vertexSamplers[i] = nil;
+        commandBuffer->vertexTextures[i] = nil;
+        commandBuffer->fragmentSamplers[i] = nil;
+        commandBuffer->fragmentTextures[i] = nil;
     }
     for (i = 0; i < MAX_STORAGE_TEXTURES_PER_STAGE; i += 1) {
-        command_buffer->vertexStorageTextures[i] = nil;
-        command_buffer->fragmentStorageTextures[i] = nil;
-        command_buffer->computeReadOnlyTextures[i] = nil;
+        commandBuffer->vertexStorageTextures[i] = nil;
+        commandBuffer->fragmentStorageTextures[i] = nil;
+        commandBuffer->computeReadOnlyTextures[i] = nil;
     }
     for (i = 0; i < MAX_STORAGE_BUFFERS_PER_STAGE; i += 1) {
-        command_buffer->vertexStorageBuffers[i] = nil;
-        command_buffer->fragmentStorageBuffers[i] = nil;
-        command_buffer->computeReadOnlyBuffers[i] = nil;
+        commandBuffer->vertexStorageBuffers[i] = nil;
+        commandBuffer->fragmentStorageBuffers[i] = nil;
+        commandBuffer->computeReadOnlyBuffers[i] = nil;
     }
     for (i = 0; i < MAX_COMPUTE_WRITE_TEXTURES; i += 1) {
-        command_buffer->computeWriteOnlyTextures[i] = nil;
+        commandBuffer->computeWriteOnlyTextures[i] = nil;
     }
     for (i = 0; i < MAX_COMPUTE_WRITE_BUFFERS; i += 1) {
-        command_buffer->computeWriteOnlyBuffers[i] = nil;
+        commandBuffer->computeWriteOnlyBuffers[i] = nil;
     }
 
     // The fence is now available (unless SubmitAndAcquireFence was called)
-    if (command_buffer->autoReleaseFence) {
+    if (commandBuffer->autoReleaseFence) {
         METAL_ReleaseFence(
             (SDL_GPURenderer *)renderer,
-            (SDL_GPUFence *)command_buffer->fence);
+            (SDL_GPUFence *)commandBuffer->fence);
     }
 
     // Return command buffer to pool
@@ -3242,13 +3242,13 @@ static void METAL_INTERNAL_CleanCommandBuffer(
             renderer->availableCommandBuffers,
             renderer->availableCommandBufferCapacity * sizeof(MetalCommandBuffer *));
     }
-    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
+    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
     renderer->availableCommandBufferCount += 1;
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
     // Remove this command buffer from the submitted list
     for (i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-        if (renderer->submittedCommandBuffers[i] == command_buffer) {
+        if (renderer->submittedCommandBuffers[i] == commandBuffer) {
             renderer->submittedCommandBuffers[i] = renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount - 1];
             renderer->submittedCommandBufferCount -= 1;
         }
@@ -3298,16 +3298,16 @@ static void METAL_INTERNAL_PerformPendingDestroys(
 
 static void METAL_WaitForFences(
     SDL_GPURenderer *driverData,
-    bool wait_all,
+    bool waitAll,
     SDL_GPUFence *const *fences,
-    Uint32 num_fences)
+    Uint32 numFences)
 {
     @autoreleasepool {
         MetalRenderer *renderer = (MetalRenderer *)driverData;
         bool waiting;
 
-        if (wait_all) {
-            for (Uint32 i = 0; i < num_fences; i += 1) {
+        if (waitAll) {
+            for (Uint32 i = 0; i < numFences; i += 1) {
                 while (!SDL_AtomicGet(&((MetalFence *)fences[i])->complete)) {
                     // Spin!
                 }
@@ -3315,7 +3315,7 @@ static void METAL_WaitForFences(
         } else {
             waiting = 1;
             while (waiting) {
-                for (Uint32 i = 0; i < num_fences; i += 1) {
+                for (Uint32 i = 0; i < numFences; i += 1) {
                     if (SDL_AtomicGet(&((MetalFence *)fences[i])->complete) > 0) {
                         waiting = 0;
                         break;
@@ -3347,7 +3347,7 @@ static MetalWindowData *METAL_INTERNAL_FetchWindowData(SDL_Window *window)
 static bool METAL_SupportsSwapchainComposition(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition)
+    SDL_GPUSwapchainComposition swapchainComposition)
 {
 #ifndef SDL_PLATFORM_MACOS
     if (swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048) {
@@ -3358,7 +3358,7 @@ static bool METAL_SupportsSwapchainComposition(
     if (@available(macOS 11.0, *)) {
         return true;
     } else {
-        return swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048;
+        return swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048;
     }
 }
 
@@ -3366,8 +3366,8 @@ static bool METAL_SupportsSwapchainComposition(
 static Uint8 METAL_INTERNAL_CreateSwapchain(
     MetalRenderer *renderer,
     MetalWindowData *windowData,
-    SDL_GPUSwapchainComposition swapchain_composition,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUSwapchainComposition swapchainComposition,
+    SDL_GPUPresentMode presentMode)
 {
     CGColorSpaceRef colorspace;
     CGSize drawableSize;
@@ -3378,14 +3378,14 @@ static Uint8 METAL_INTERNAL_CreateSwapchain(
     windowData->layer = (__bridge CAMetalLayer *)(SDL_Metal_GetLayer(windowData->view));
     windowData->layer.device = renderer->device;
 #ifdef SDL_PLATFORM_MACOS
-    windowData->layer.displaySyncEnabled = (present_mode != SDL_GPU_PRESENTMODE_IMMEDIATE);
+    windowData->layer.displaySyncEnabled = (presentMode != SDL_GPU_PRESENTMODE_IMMEDIATE);
 #endif
-    windowData->layer.pixelFormat = SDLToMetal_SurfaceFormat[SwapchainCompositionToFormat[swapchain_composition]];
+    windowData->layer.pixelFormat = SDLToMetal_SurfaceFormat[SwapchainCompositionToFormat[swapchainComposition]];
 #ifndef SDL_PLATFORM_TVOS
-    windowData->layer.wantsExtendedDynamicRangeContent = (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR);
+    windowData->layer.wantsExtendedDynamicRangeContent = (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR);
 #endif
 
-    colorspace = CGColorSpaceCreateWithName(SwapchainCompositionToColorSpace[swapchain_composition]);
+    colorspace = CGColorSpaceCreateWithName(SwapchainCompositionToColorSpace[swapchainComposition]);
     windowData->layer.colorspace = colorspace;
     CGColorSpaceRelease(colorspace);
 
@@ -3396,7 +3396,7 @@ static Uint8 METAL_INTERNAL_CreateSwapchain(
         SDL_GPU_FetchBlitPipeline(
             renderer->sdlGPUDevice,
             (SDL_GPUTextureType)i,
-            SwapchainCompositionToFormat[swapchain_composition],
+            SwapchainCompositionToFormat[swapchainComposition],
             renderer->blitVertexShader,
             renderer->blitFrom2DShader,
             renderer->blitFrom2DArrayShader,
@@ -3413,11 +3413,11 @@ static Uint8 METAL_INTERNAL_CreateSwapchain(
     windowData->textureContainer.activeTexture = &windowData->texture;
     windowData->textureContainer.textureCapacity = 1;
     windowData->textureContainer.textureCount = 1;
-    windowData->textureContainer.header.info.format = SwapchainCompositionToFormat[swapchain_composition];
+    windowData->textureContainer.header.info.format = SwapchainCompositionToFormat[swapchainComposition];
     windowData->textureContainer.header.info.num_levels = 1;
     windowData->textureContainer.header.info.layer_count_or_depth = 1;
     windowData->textureContainer.header.info.type = SDL_GPU_TEXTURETYPE_2D;
-    windowData->textureContainer.header.info.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+    windowData->textureContainer.header.info.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
 
     drawableSize = windowData->layer.drawableSize;
     windowData->textureContainer.header.info.width = (Uint32)drawableSize.width;
@@ -3429,9 +3429,9 @@ static Uint8 METAL_INTERNAL_CreateSwapchain(
 static bool METAL_SupportsPresentMode(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUPresentMode presentMode)
 {
-    switch (present_mode) {
+    switch (presentMode) {
 #ifdef SDL_PLATFORM_MACOS
     case SDL_GPU_PRESENTMODE_IMMEDIATE:
 #endif
@@ -3515,13 +3515,13 @@ static void METAL_ReleaseWindow(
 }
 
 static SDL_GPUTexture *METAL_AcquireSwapchainTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_Window *window,
     Uint32 *w,
     Uint32 *h)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalWindowData *windowData;
         CGSize drawableSize;
 
@@ -3575,8 +3575,8 @@ static SDL_GPUTextureFormat METAL_GetSwapchainTextureFormat(
 static bool METAL_SetSwapchainParameters(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUSwapchainComposition swapchainComposition,
+    SDL_GPUPresentMode presentMode)
 {
     @autoreleasepool {
         MetalWindowData *windowData = METAL_INTERNAL_FetchWindowData(window);
@@ -3587,12 +3587,12 @@ static bool METAL_SetSwapchainParameters(
             return false;
         }
 
-        if (!METAL_SupportsSwapchainComposition(driverData, window, swapchain_composition)) {
+        if (!METAL_SupportsSwapchainComposition(driverData, window, swapchainComposition)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Swapchain composition not supported!");
             return false;
         }
 
-        if (!METAL_SupportsPresentMode(driverData, window, present_mode)) {
+        if (!METAL_SupportsPresentMode(driverData, window, presentMode)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Present mode not supported!");
             return false;
         }
@@ -3600,18 +3600,18 @@ static bool METAL_SetSwapchainParameters(
         METAL_Wait(driverData);
 
 #ifdef SDL_PLATFORM_MACOS
-        windowData->layer.displaySyncEnabled = (present_mode != SDL_GPU_PRESENTMODE_IMMEDIATE);
+        windowData->layer.displaySyncEnabled = (presentMode != SDL_GPU_PRESENTMODE_IMMEDIATE);
 #endif
-        windowData->layer.pixelFormat = SDLToMetal_SurfaceFormat[SwapchainCompositionToFormat[swapchain_composition]];
+        windowData->layer.pixelFormat = SDLToMetal_SurfaceFormat[SwapchainCompositionToFormat[swapchainComposition]];
 #ifndef SDL_PLATFORM_TVOS
-        windowData->layer.wantsExtendedDynamicRangeContent = (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR);
+        windowData->layer.wantsExtendedDynamicRangeContent = (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR);
 #endif
 
-        colorspace = CGColorSpaceCreateWithName(SwapchainCompositionToColorSpace[swapchain_composition]);
+        colorspace = CGColorSpaceCreateWithName(SwapchainCompositionToColorSpace[swapchainComposition]);
         windowData->layer.colorspace = colorspace;
         CGColorSpaceRelease(colorspace);
 
-        windowData->textureContainer.header.info.format = SwapchainCompositionToFormat[swapchain_composition];
+        windowData->textureContainer.header.info.format = SwapchainCompositionToFormat[swapchainComposition];
 
         return true;
     }
@@ -3620,10 +3620,10 @@ static bool METAL_SetSwapchainParameters(
 // Submission
 
 static void METAL_Submit(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     @autoreleasepool {
-        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+        MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
         MetalRenderer *renderer = metalCommandBuffer->renderer;
 
         SDL_LockMutex(renderer->submitLock);
@@ -3670,13 +3670,13 @@ static void METAL_Submit(
 }
 
 static SDL_GPUFence *METAL_SubmitAndAcquireFence(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)command_buffer;
+    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalFence *fence = metalCommandBuffer->fence;
 
     metalCommandBuffer->autoReleaseFence = 0;
-    METAL_Submit(command_buffer);
+    METAL_Submit(commandBuffer);
 
     return (SDL_GPUFence *)fence;
 }
@@ -3686,7 +3686,7 @@ static void METAL_Wait(
 {
     @autoreleasepool {
         MetalRenderer *renderer = (MetalRenderer *)driverData;
-        MetalCommandBuffer *command_buffer;
+        MetalCommandBuffer *commandBuffer;
 
         /*
          * Wait for all submitted command buffers to complete.
@@ -3701,8 +3701,8 @@ static void METAL_Wait(
         SDL_LockMutex(renderer->submitLock);
 
         for (Sint32 i = renderer->submittedCommandBufferCount - 1; i >= 0; i -= 1) {
-            command_buffer = renderer->submittedCommandBuffers[i];
-            METAL_INTERNAL_CleanCommandBuffer(renderer, command_buffer);
+            commandBuffer = renderer->submittedCommandBuffers[i];
+            METAL_INTERNAL_CleanCommandBuffer(renderer, commandBuffer);
         }
 
         METAL_INTERNAL_PerformPendingDestroys(renderer);
@@ -3779,10 +3779,10 @@ static bool METAL_SupportsTextureFormat(
 
 // Device Creation
 
-static bool METAL_PrepareDriver(SDL_VideoDevice *_this)
+static bool METAL_PrepareDriver(SDL_VideoDevice *this)
 {
     // FIXME: Add a macOS / iOS version check! Maybe support >= 10.14?
-    return (_this->Metal_CreateView != NULL);
+    return (this->Metal_CreateView != NULL);
 }
 
 static void METAL_INTERNAL_InitBlitResources(
@@ -3803,7 +3803,7 @@ static void METAL_INTERNAL_InitBlitResources(
     shaderModuleCreateInfo.code_size = FullscreenVert_metallib_len;
     shaderModuleCreateInfo.stage = SDL_GPU_SHADERSTAGE_VERTEX;
     shaderModuleCreateInfo.format = SDL_GPU_SHADERFORMAT_METALLIB;
-    shaderModuleCreateInfo.entrypoint_name = "FullscreenVert";
+    shaderModuleCreateInfo.entrypoint = "FullscreenVert";
 
     renderer->blitVertexShader = METAL_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -3817,7 +3817,7 @@ static void METAL_INTERNAL_InitBlitResources(
     shaderModuleCreateInfo.code = BlitFrom2D_metallib;
     shaderModuleCreateInfo.code_size = BlitFrom2D_metallib_len;
     shaderModuleCreateInfo.stage = SDL_GPU_SHADERSTAGE_FRAGMENT;
-    shaderModuleCreateInfo.entrypoint_name = "BlitFrom2D";
+    shaderModuleCreateInfo.entrypoint = "BlitFrom2D";
     shaderModuleCreateInfo.num_samplers = 1;
     shaderModuleCreateInfo.num_uniform_buffers = 1;
 
@@ -3832,7 +3832,7 @@ static void METAL_INTERNAL_InitBlitResources(
     // BlitFrom2DArray fragment shader
     shaderModuleCreateInfo.code = BlitFrom2DArray_metallib;
     shaderModuleCreateInfo.code_size = BlitFrom2DArray_metallib_len;
-    shaderModuleCreateInfo.entrypoint_name = "BlitFrom2DArray";
+    shaderModuleCreateInfo.entrypoint = "BlitFrom2DArray";
 
     renderer->blitFrom2DArrayShader = METAL_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -3845,7 +3845,7 @@ static void METAL_INTERNAL_InitBlitResources(
     // BlitFrom3D fragment shader
     shaderModuleCreateInfo.code = BlitFrom3D_metallib;
     shaderModuleCreateInfo.code_size = BlitFrom3D_metallib_len;
-    shaderModuleCreateInfo.entrypoint_name = "BlitFrom3D";
+    shaderModuleCreateInfo.entrypoint = "BlitFrom3D";
 
     renderer->blitFrom3DShader = METAL_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -3858,7 +3858,7 @@ static void METAL_INTERNAL_InitBlitResources(
     // BlitFromCube fragment shader
     shaderModuleCreateInfo.code = BlitFromCube_metallib;
     shaderModuleCreateInfo.code_size = BlitFromCube_metallib_len;
-    shaderModuleCreateInfo.entrypoint_name = "BlitFromCube";
+    shaderModuleCreateInfo.entrypoint = "BlitFromCube";
 
     renderer->blitFromCubeShader = METAL_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -3922,7 +3922,7 @@ static void METAL_INTERNAL_DestroyBlitResources(
     SDL_free(renderer->blitPipelines);
 }
 
-static SDL_GPUDevice *METAL_CreateDevice(bool debug_mode, bool preferLowPower, SDL_PropertiesID props)
+static SDL_GPUDevice *METAL_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
 {
     @autoreleasepool {
         MetalRenderer *renderer;
@@ -3955,7 +3955,7 @@ static SDL_GPUDevice *METAL_CreateDevice(bool debug_mode, bool preferLowPower, S
             [renderer->device.name UTF8String]);
 
         // Remember debug mode
-        renderer->debug_mode = debug_mode;
+        renderer->debug_mode = debugMode;
 
         // Set up colorspace array
         SwapchainCompositionToColorSpace[0] = kCGColorSpaceSRGB;

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -580,7 +580,7 @@ struct VulkanBuffer
     VulkanMemoryUsedRegion *usedRegion;
 
     VulkanBufferType type;
-    SDL_GPUBufferUsageFlags usage_flags;
+    SDL_GPUBufferUsageFlags usageFlags;
 
     SDL_AtomicInt referenceCount; // Tracks command buffer usage
 
@@ -630,11 +630,11 @@ typedef struct VulkanSampler
 typedef struct VulkanShader
 {
     VkShaderModule shaderModule;
-    const char *entrypoint_name;
-    Uint32 num_samplers;
-    Uint32 num_storage_textures;
-    Uint32 num_storage_buffers;
-    Uint32 num_uniform_buffers;
+    const char *entrypointName;
+    Uint32 numSamplers;
+    Uint32 numStorageTextures;
+    Uint32 numStorageBuffers;
+    Uint32 numUniformBuffers;
     SDL_AtomicInt referenceCount;
 } VulkanShader;
 
@@ -675,11 +675,11 @@ struct VulkanTexture
 
     Uint32 depth;
     Uint32 layerCount;
-    Uint32 num_levels;
-    VkSampleCountFlagBits sample_count; // NOTE: This refers to the sample count of a render target pass using this texture, not the actual sample count of the texture
+    Uint32 numLevels;
+    VkSampleCountFlagBits sampleCount; // NOTE: This refers to the sample count of a render target pass using this texture, not the actual sample count of the texture
     VkFormat format;
     VkComponentMapping swizzle;
-    SDL_GPUTextureUsageFlags usage_flags;
+    SDL_GPUTextureUsageFlags usageFlags;
     VkImageAspectFlags aspectFlags;
 
     Uint32 subresourceCount;
@@ -765,7 +765,7 @@ typedef struct VulkanSwapchainData
     VkFormat format;
     VkColorSpaceKHR colorSpace;
     VkComponentMapping swapchainSwizzle;
-    VkPresentModeKHR present_mode;
+    VkPresentModeKHR presentMode;
     bool usingFallbackFormat;
 
     // Swapchain images
@@ -783,8 +783,8 @@ typedef struct VulkanSwapchainData
 typedef struct WindowData
 {
     SDL_Window *window;
-    SDL_GPUSwapchainComposition swapchain_composition;
-    SDL_GPUPresentMode present_mode;
+    SDL_GPUSwapchainComposition swapchainComposition;
+    SDL_GPUPresentMode presentMode;
     VulkanSwapchainData *swapchainData;
     bool needsSwapchainRecreate;
 } WindowData;
@@ -864,12 +864,12 @@ typedef struct VulkanGraphicsPipelineResourceLayout
 typedef struct VulkanGraphicsPipeline
 {
     VkPipeline pipeline;
-    SDL_GPUPrimitiveType primitive_type;
+    SDL_GPUPrimitiveType primitiveType;
 
     VulkanGraphicsPipelineResourceLayout resourceLayout;
 
-    VulkanShader *vertex_shader;
-    VulkanShader *fragment_shader;
+    VulkanShader *vertexShader;
+    VulkanShader *fragmentShader;
 
     SDL_AtomicInt referenceCount;
 } VulkanGraphicsPipeline;
@@ -886,11 +886,11 @@ typedef struct VulkanComputePipelineResourceLayout
      */
     DescriptorSetPool descriptorSetPools[3];
 
-    Uint32 num_readonly_storage_textures;
-    Uint32 num_readonly_storage_buffers;
-    Uint32 num_writeonly_storage_textures;
-    Uint32 num_writeonly_storage_buffers;
-    Uint32 num_uniform_buffers;
+    Uint32 numReadonlyStorageTextures;
+    Uint32 numReadonlyStorageBuffers;
+    Uint32 numWriteonlyStorageTextures;
+    Uint32 numWriteonlyStorageBuffers;
+    Uint32 numUniformBuffers;
 } VulkanComputePipelineResourceLayout;
 
 typedef struct VulkanComputePipeline
@@ -904,17 +904,17 @@ typedef struct VulkanComputePipeline
 typedef struct RenderPassColorTargetDescription
 {
     VkFormat format;
-    SDL_GPULoadOp load_op;
-    SDL_GPUStoreOp store_op;
+    SDL_GPULoadOp loadOp;
+    SDL_GPUStoreOp storeOp;
 } RenderPassColorTargetDescription;
 
 typedef struct RenderPassDepthStencilTargetDescription
 {
     VkFormat format;
-    SDL_GPULoadOp load_op;
-    SDL_GPUStoreOp store_op;
-    SDL_GPULoadOp stencil_load_op;
-    SDL_GPUStoreOp stencil_store_op;
+    SDL_GPULoadOp loadOp;
+    SDL_GPUStoreOp storeOp;
+    SDL_GPULoadOp stencilLoadOp;
+    SDL_GPUStoreOp stencilStoreOp;
 } RenderPassDepthStencilTargetDescription;
 
 typedef struct CommandPoolHashTableKey
@@ -925,7 +925,7 @@ typedef struct CommandPoolHashTableKey
 typedef struct RenderPassHashTableKey
 {
     RenderPassColorTargetDescription colorTargetDescriptions[MAX_COLOR_TARGET_BINDINGS];
-    Uint32 num_color_attachments;
+    Uint32 numColorAttachments;
     RenderPassDepthStencilTargetDescription depthStencilTargetDescription;
     VkSampleCountFlagBits colorAttachmentSampleCount;
 } RenderPassHashTableKey;
@@ -939,7 +939,7 @@ typedef struct FramebufferHashTableKey
 {
     VkImageView colorAttachmentViews[MAX_COLOR_TARGET_BINDINGS];
     VkImageView colorMultiSampleAttachmentViews[MAX_COLOR_TARGET_BINDINGS];
-    Uint32 num_color_attachments;
+    Uint32 numColorAttachments;
     VkImageView depthStencilAttachmentView;
     Uint32 width;
     Uint32 height;
@@ -971,7 +971,7 @@ typedef struct VulkanCommandBuffer
     CommandBufferCommonHeader common;
     VulkanRenderer *renderer;
 
-    VkCommandBuffer command_buffer;
+    VkCommandBuffer commandBuffer;
     VulkanCommandPool *commandPool;
 
     VulkanPresentData *presentDatas;
@@ -1000,7 +1000,7 @@ typedef struct VulkanCommandBuffer
 
     VkViewport currentViewport;
     VkRect2D currentScissor;
-    float blend_constants[4];
+    float blendConstants[4];
     Uint8 stencilRef;
 
     // Resource bind state
@@ -1113,7 +1113,7 @@ struct VulkanRenderer
     Uint8 outofBARMemoryWarning;
     Uint8 fillModeOnlyWarning;
 
-    bool debug_mode;
+    bool debugMode;
     bool preferLowPower;
     VulkanExtensions supports;
     bool supportsDebugUtils;
@@ -1205,11 +1205,11 @@ struct VulkanRenderer
 // Forward declarations
 
 static Uint8 VULKAN_INTERNAL_DefragmentMemory(VulkanRenderer *renderer);
-static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer, VulkanCommandBuffer *command_buffer);
+static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer, VulkanCommandBuffer *commandBuffer);
 static void VULKAN_ReleaseWindow(SDL_GPURenderer *driverData, SDL_Window *window);
 static void VULKAN_Wait(SDL_GPURenderer *driverData);
-static void VULKAN_WaitForFences(SDL_GPURenderer *driverData, bool wait_all, SDL_GPUFence *const *fences, Uint32 num_fences);
-static void VULKAN_Submit(SDL_GPUCommandBuffer *command_buffer);
+static void VULKAN_WaitForFences(SDL_GPURenderer *driverData, bool waitAll, SDL_GPUFence *const *fences, Uint32 numFences);
+static void VULKAN_Submit(SDL_GPUCommandBuffer *commandBuffer);
 static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     VulkanRenderer *renderer,
     Uint32 width,
@@ -1217,8 +1217,8 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 num_levels,
-    VkSampleCountFlagBits sample_count,
+    Uint32 numLevels,
+    VkSampleCountFlagBits sampleCount,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -2453,10 +2453,10 @@ static void VULKAN_INTERNAL_TrackSampler(
 
 static void VULKAN_INTERNAL_TrackGraphicsPipeline(
     VulkanCommandBuffer *command_buffer,
-    VulkanGraphicsPipeline *graphics_pipeline)
+    VulkanGraphicsPipeline *graphicsPipeline)
 {
     TRACK_RESOURCE(
-        graphics_pipeline,
+        graphicsPipeline,
         VulkanGraphicsPipeline *,
         usedGraphicsPipelines,
         usedGraphicsPipelineCount,
@@ -2465,10 +2465,10 @@ static void VULKAN_INTERNAL_TrackGraphicsPipeline(
 
 static void VULKAN_INTERNAL_TrackComputePipeline(
     VulkanCommandBuffer *command_buffer,
-    VulkanComputePipeline *compute_pipeline)
+    VulkanComputePipeline *computePipeline)
 {
     TRACK_RESOURCE(
-        compute_pipeline,
+        computePipeline,
         VulkanComputePipeline *,
         usedComputePipelines,
         usedComputePipelineCount,
@@ -2489,27 +2489,27 @@ static void VULKAN_INTERNAL_TrackFramebuffer(
 }
 
 static void VULKAN_INTERNAL_TrackUniformBuffer(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanUniformBuffer *uniformBuffer)
 {
     Uint32 i;
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
-        if (command_buffer->usedUniformBuffers[i] == uniformBuffer) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
+        if (commandBuffer->usedUniformBuffers[i] == uniformBuffer) {
             return;
         }
     }
 
-    if (command_buffer->usedUniformBufferCount == command_buffer->usedUniformBufferCapacity) {
-        command_buffer->usedUniformBufferCapacity += 1;
-        command_buffer->usedUniformBuffers = SDL_realloc(
-            command_buffer->usedUniformBuffers,
-            command_buffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
+    if (commandBuffer->usedUniformBufferCount == commandBuffer->usedUniformBufferCapacity) {
+        commandBuffer->usedUniformBufferCapacity += 1;
+        commandBuffer->usedUniformBuffers = SDL_realloc(
+            commandBuffer->usedUniformBuffers,
+            commandBuffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
     }
-    command_buffer->usedUniformBuffers[command_buffer->usedUniformBufferCount] = uniformBuffer;
-    command_buffer->usedUniformBufferCount += 1;
+    commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
+    commandBuffer->usedUniformBufferCount += 1;
 
     VULKAN_INTERNAL_TrackBuffer(
-        command_buffer,
+        commandBuffer,
         uniformBuffer->bufferHandle->vulkanBuffer);
 }
 
@@ -2554,7 +2554,7 @@ static void VULKAN_INTERNAL_TrackUniformBuffer(
 
 static void VULKAN_INTERNAL_BufferMemoryBarrier(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBufferUsageMode sourceUsageMode,
     VulkanBufferUsageMode destinationUsageMode,
     VulkanBuffer *buffer)
@@ -2632,7 +2632,7 @@ static void VULKAN_INTERNAL_BufferMemoryBarrier(
     }
 
     renderer->vkCmdPipelineBarrier(
-        command_buffer->command_buffer,
+        commandBuffer->commandBuffer,
         srcStages,
         dstStages,
         0,
@@ -2648,7 +2648,7 @@ static void VULKAN_INTERNAL_BufferMemoryBarrier(
 
 static void VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTextureSubresource *textureSubresource)
@@ -2755,7 +2755,7 @@ static void VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
     }
 
     renderer->vkCmdPipelineBarrier(
-        command_buffer->command_buffer,
+        commandBuffer->commandBuffer,
         srcStages,
         dstStages,
         0,
@@ -2774,17 +2774,17 @@ static VulkanBufferUsageMode VULKAN_INTERNAL_DefaultBufferUsageMode(
 {
     // NOTE: order matters here!
 
-    if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         return VULKAN_BUFFER_USAGE_MODE_VERTEX_READ;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
         return VULKAN_BUFFER_USAGE_MODE_INDEX_READ;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         return VULKAN_BUFFER_USAGE_MODE_INDIRECT;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
         return VULKAN_BUFFER_USAGE_MODE_GRAPHICS_STORAGE_READ;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ) {
         return VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         return VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Buffer has no default usage mode!");
@@ -2798,17 +2798,17 @@ static VulkanTextureUsageMode VULKAN_INTERNAL_DefaultTextureUsageMode(
     // NOTE: order matters here!
     // NOTE: graphics storage bits and sampler bit are mutually exclusive!
 
-    if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
+    if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
         return VULKAN_TEXTURE_USAGE_MODE_SAMPLER;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
         return VULKAN_TEXTURE_USAGE_MODE_GRAPHICS_STORAGE_READ;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
         return VULKAN_TEXTURE_USAGE_MODE_COLOR_ATTACHMENT;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
         return VULKAN_TEXTURE_USAGE_MODE_DEPTH_STENCIL_ATTACHMENT;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
         return VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
         return VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Texture has no default usage mode!");
@@ -2818,13 +2818,13 @@ static VulkanTextureUsageMode VULKAN_INTERNAL_DefaultTextureUsageMode(
 
 static void VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBufferUsageMode destinationUsageMode,
     VulkanBuffer *buffer)
 {
     VULKAN_INTERNAL_BufferMemoryBarrier(
         renderer,
-        command_buffer,
+        commandBuffer,
         VULKAN_INTERNAL_DefaultBufferUsageMode(buffer),
         destinationUsageMode,
         buffer);
@@ -2832,13 +2832,13 @@ static void VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBufferUsageMode sourceUsageMode,
     VulkanBuffer *buffer)
 {
     VULKAN_INTERNAL_BufferMemoryBarrier(
         renderer,
-        command_buffer,
+        commandBuffer,
         sourceUsageMode,
         VULKAN_INTERNAL_DefaultBufferUsageMode(buffer),
         buffer);
@@ -2846,13 +2846,13 @@ static void VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTextureSubresource *textureSubresource)
 {
     VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
         renderer,
-        command_buffer,
+        commandBuffer,
         VULKAN_INTERNAL_DefaultTextureUsageMode(textureSubresource->parent),
         destinationUsageMode,
         textureSubresource);
@@ -2860,14 +2860,14 @@ static void VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTexture *texture)
 {
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
             renderer,
-            command_buffer,
+            commandBuffer,
             destinationUsageMode,
             &texture->subresources[i]);
     }
@@ -2875,13 +2875,13 @@ static void VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTextureSubresource *textureSubresource)
 {
     VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
         renderer,
-        command_buffer,
+        commandBuffer,
         sourceUsageMode,
         VULKAN_INTERNAL_DefaultTextureUsageMode(textureSubresource->parent),
         textureSubresource);
@@ -2889,7 +2889,7 @@ static void VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTexture *texture)
 {
@@ -2897,7 +2897,7 @@ static void VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
             renderer,
-            command_buffer,
+            commandBuffer,
             sourceUsageMode,
             &texture->subresources[i]);
     }
@@ -2953,7 +2953,7 @@ static void VULKAN_INTERNAL_RemoveFramebuffersContainingView(
 
     while (SDL_IterateHashTable(renderer->framebufferHashTable, (const void **)&key, (const void **)&value, &iter)) {
         bool remove = false;
-        for (Uint32 i = 0; i < key->num_color_attachments; i += 1) {
+        for (Uint32 i = 0; i < key->numColorAttachments; i += 1) {
             if (key->colorAttachmentViews[i] == view) {
                 remove = true;
             }
@@ -2990,7 +2990,7 @@ static void VULKAN_INTERNAL_DestroyTexture(
 {
     // Clean up subresources
     for (Uint32 subresourceIndex = 0; subresourceIndex < texture->subresourceCount; subresourceIndex += 1) {
-        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
             for (Uint32 depthIndex = 0; depthIndex < texture->depth; depthIndex += 1) {
                 VULKAN_INTERNAL_RemoveFramebuffersContainingView(
                     renderer,
@@ -3013,14 +3013,14 @@ static void VULKAN_INTERNAL_DestroyTexture(
             SDL_free(texture->subresources[subresourceIndex].renderTargetViews);
         }
 
-        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
             renderer->vkDestroyImageView(
                 renderer->logicalDevice,
                 texture->subresources[subresourceIndex].computeWriteView,
                 NULL);
         }
 
-        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
             renderer->vkDestroyImageView(
                 renderer->logicalDevice,
                 texture->subresources[subresourceIndex].depthStencilView,
@@ -3068,7 +3068,7 @@ static void VULKAN_INTERNAL_DestroyCommandPool(
     VulkanCommandPool *commandPool)
 {
     Uint32 i;
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
 
     renderer->vkDestroyCommandPool(
         renderer->logicalDevice,
@@ -3076,21 +3076,21 @@ static void VULKAN_INTERNAL_DestroyCommandPool(
         NULL);
 
     for (i = 0; i < commandPool->inactiveCommandBufferCount; i += 1) {
-        command_buffer = commandPool->inactiveCommandBuffers[i];
+        commandBuffer = commandPool->inactiveCommandBuffers[i];
 
-        SDL_free(command_buffer->presentDatas);
-        SDL_free(command_buffer->waitSemaphores);
-        SDL_free(command_buffer->signalSemaphores);
-        SDL_free(command_buffer->boundDescriptorSetDatas);
-        SDL_free(command_buffer->usedBuffers);
-        SDL_free(command_buffer->usedTextures);
-        SDL_free(command_buffer->usedSamplers);
-        SDL_free(command_buffer->usedGraphicsPipelines);
-        SDL_free(command_buffer->usedComputePipelines);
-        SDL_free(command_buffer->usedFramebuffers);
-        SDL_free(command_buffer->usedUniformBuffers);
+        SDL_free(commandBuffer->presentDatas);
+        SDL_free(commandBuffer->waitSemaphores);
+        SDL_free(commandBuffer->signalSemaphores);
+        SDL_free(commandBuffer->boundDescriptorSetDatas);
+        SDL_free(commandBuffer->usedBuffers);
+        SDL_free(commandBuffer->usedTextures);
+        SDL_free(commandBuffer->usedSamplers);
+        SDL_free(commandBuffer->usedGraphicsPipelines);
+        SDL_free(commandBuffer->usedComputePipelines);
+        SDL_free(commandBuffer->usedFramebuffers);
+        SDL_free(commandBuffer->usedUniformBuffers);
 
-        SDL_free(command_buffer);
+        SDL_free(commandBuffer);
     }
 
     SDL_free(commandPool->inactiveCommandBuffers);
@@ -3127,60 +3127,60 @@ static void VULKAN_INTERNAL_DestroyDescriptorSetPool(
 
 static void VULKAN_INTERNAL_DestroyGraphicsPipeline(
     VulkanRenderer *renderer,
-    VulkanGraphicsPipeline *graphics_pipeline)
+    VulkanGraphicsPipeline *graphicsPipeline)
 {
     Uint32 i;
 
     renderer->vkDestroyPipeline(
         renderer->logicalDevice,
-        graphics_pipeline->pipeline,
+        graphicsPipeline->pipeline,
         NULL);
 
     renderer->vkDestroyPipelineLayout(
         renderer->logicalDevice,
-        graphics_pipeline->resourceLayout.pipelineLayout,
+        graphicsPipeline->resourceLayout.pipelineLayout,
         NULL);
 
     for (i = 0; i < 4; i += 1) {
         VULKAN_INTERNAL_DestroyDescriptorSetPool(
             renderer,
-            &graphics_pipeline->resourceLayout.descriptorSetPools[i]);
+            &graphicsPipeline->resourceLayout.descriptorSetPools[i]);
     }
 
-    (void)SDL_AtomicDecRef(&graphics_pipeline->vertex_shader->referenceCount);
-    (void)SDL_AtomicDecRef(&graphics_pipeline->fragment_shader->referenceCount);
+    (void)SDL_AtomicDecRef(&graphicsPipeline->vertexShader->referenceCount);
+    (void)SDL_AtomicDecRef(&graphicsPipeline->fragmentShader->referenceCount);
 
-    SDL_free(graphics_pipeline);
+    SDL_free(graphicsPipeline);
 }
 
 static void VULKAN_INTERNAL_DestroyComputePipeline(
     VulkanRenderer *renderer,
-    VulkanComputePipeline *compute_pipeline)
+    VulkanComputePipeline *computePipeline)
 {
     Uint32 i;
 
     renderer->vkDestroyPipeline(
         renderer->logicalDevice,
-        compute_pipeline->pipeline,
+        computePipeline->pipeline,
         NULL);
 
     renderer->vkDestroyPipelineLayout(
         renderer->logicalDevice,
-        compute_pipeline->resourceLayout.pipelineLayout,
+        computePipeline->resourceLayout.pipelineLayout,
         NULL);
 
     for (i = 0; i < 3; i += 1) {
         VULKAN_INTERNAL_DestroyDescriptorSetPool(
             renderer,
-            &compute_pipeline->resourceLayout.descriptorSetPools[i]);
+            &computePipeline->resourceLayout.descriptorSetPools[i]);
     }
 
     renderer->vkDestroyShaderModule(
         renderer->logicalDevice,
-        compute_pipeline->shaderModule,
+        computePipeline->shaderModule,
         NULL);
 
-    SDL_free(compute_pipeline);
+    SDL_free(computePipeline);
 }
 
 static void VULKAN_INTERNAL_DestroyShader(
@@ -3192,7 +3192,7 @@ static void VULKAN_INTERNAL_DestroyShader(
         vulkanShader->shaderModule,
         NULL);
 
-    SDL_free((void *)vulkanShader->entrypoint_name);
+    SDL_free((void *)vulkanShader->entrypointName);
     SDL_free(vulkanShader);
 }
 
@@ -3300,22 +3300,22 @@ static Uint32 VULKAN_INTERNAL_RenderPassHashFunction(
      * is taken from Josh Bloch's "Effective Java".
      * (https://stackoverflow.com/a/113600/12492383)
      */
-    const Uint32 HASH_FACTOR = 31;
+    const Uint32 hashFactor = 31;
     Uint32 result = 1;
 
-    for (Uint32 i = 0; i < hashTableKey->num_color_attachments; i += 1) {
-        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].load_op;
-        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].store_op;
-        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].format;
+    for (Uint32 i = 0; i < hashTableKey->numColorAttachments; i += 1) {
+        result = result * hashFactor + hashTableKey->colorTargetDescriptions[i].loadOp;
+        result = result * hashFactor + hashTableKey->colorTargetDescriptions[i].storeOp;
+        result = result * hashFactor + hashTableKey->colorTargetDescriptions[i].format;
     }
 
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.load_op;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.store_op;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.stencil_load_op;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.stencil_store_op;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.format;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.loadOp;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.storeOp;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.stencilLoadOp;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.stencilStoreOp;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.format;
 
-    result = result * HASH_FACTOR + hashTableKey->colorAttachmentSampleCount;
+    result = result * hashFactor + hashTableKey->colorAttachmentSampleCount;
 
     return result;
 }
@@ -3328,7 +3328,7 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
     RenderPassHashTableKey *a = (RenderPassHashTableKey *)aKey;
     RenderPassHashTableKey *b = (RenderPassHashTableKey *)bKey;
 
-    if (a->num_color_attachments != b->num_color_attachments) {
+    if (a->numColorAttachments != b->numColorAttachments) {
         return 0;
     }
 
@@ -3336,16 +3336,16 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
         return 0;
     }
 
-    for (Uint32 i = 0; i < a->num_color_attachments; i += 1) {
+    for (Uint32 i = 0; i < a->numColorAttachments; i += 1) {
         if (a->colorTargetDescriptions[i].format != b->colorTargetDescriptions[i].format) {
             return 0;
         }
 
-        if (a->colorTargetDescriptions[i].load_op != b->colorTargetDescriptions[i].load_op) {
+        if (a->colorTargetDescriptions[i].loadOp != b->colorTargetDescriptions[i].loadOp) {
             return 0;
         }
 
-        if (a->colorTargetDescriptions[i].store_op != b->colorTargetDescriptions[i].store_op) {
+        if (a->colorTargetDescriptions[i].storeOp != b->colorTargetDescriptions[i].storeOp) {
             return 0;
         }
     }
@@ -3354,19 +3354,19 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.load_op != b->depthStencilTargetDescription.load_op) {
+    if (a->depthStencilTargetDescription.loadOp != b->depthStencilTargetDescription.loadOp) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.store_op != b->depthStencilTargetDescription.store_op) {
+    if (a->depthStencilTargetDescription.storeOp != b->depthStencilTargetDescription.storeOp) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.stencil_load_op != b->depthStencilTargetDescription.stencil_load_op) {
+    if (a->depthStencilTargetDescription.stencilLoadOp != b->depthStencilTargetDescription.stencilLoadOp) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.stencil_store_op != b->depthStencilTargetDescription.stencil_store_op) {
+    if (a->depthStencilTargetDescription.stencilStoreOp != b->depthStencilTargetDescription.stencilStoreOp) {
         return 0;
     }
 
@@ -3395,17 +3395,17 @@ static Uint32 VULKAN_INTERNAL_FramebufferHashFunction(
      * is taken from Josh Bloch's "Effective Java".
      * (https://stackoverflow.com/a/113600/12492383)
      */
-    const Uint32 HASH_FACTOR = 31;
+    const Uint32 hashFactor = 31;
     Uint32 result = 1;
 
-    for (Uint32 i = 0; i < hashTableKey->num_color_attachments; i += 1) {
-        result = result * HASH_FACTOR + (Uint32)(uintptr_t)hashTableKey->colorAttachmentViews[i];
-        result = result * HASH_FACTOR + (Uint32)(uintptr_t)hashTableKey->colorMultiSampleAttachmentViews[i];
+    for (Uint32 i = 0; i < hashTableKey->numColorAttachments; i += 1) {
+        result = result * hashFactor + (Uint32)(uintptr_t)hashTableKey->colorAttachmentViews[i];
+        result = result * hashFactor + (Uint32)(uintptr_t)hashTableKey->colorMultiSampleAttachmentViews[i];
     }
 
-    result = result * HASH_FACTOR + (Uint32)(uintptr_t)hashTableKey->depthStencilAttachmentView;
-    result = result * HASH_FACTOR + hashTableKey->width;
-    result = result * HASH_FACTOR + hashTableKey->height;
+    result = result * hashFactor + (Uint32)(uintptr_t)hashTableKey->depthStencilAttachmentView;
+    result = result * hashFactor + hashTableKey->width;
+    result = result * hashFactor + hashTableKey->height;
 
     return result;
 }
@@ -3418,11 +3418,11 @@ static bool VULKAN_INTERNAL_FramebufferHashKeyMatch(
     FramebufferHashTableKey *a = (FramebufferHashTableKey *)aKey;
     FramebufferHashTableKey *b = (FramebufferHashTableKey *)bKey;
 
-    if (a->num_color_attachments != b->num_color_attachments) {
+    if (a->numColorAttachments != b->numColorAttachments) {
         return 0;
     }
 
-    for (Uint32 i = 0; i < a->num_color_attachments; i += 1) {
+    for (Uint32 i = 0; i < a->numColorAttachments; i += 1) {
         if (a->colorAttachmentViews[i] != b->colorAttachmentViews[i]) {
             return 0;
         }
@@ -3574,8 +3574,8 @@ static void VULKAN_INTERNAL_InitializeDescriptorSetPool(
 
 static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     VulkanRenderer *renderer,
-    VulkanShader *vertex_shader,
-    VulkanShader *fragment_shader,
+    VulkanShader *vertexShader,
+    VulkanShader *fragmentShader,
     VulkanGraphicsPipelineResourceLayout *pipelineResourceLayout)
 {
     VkDescriptorSetLayoutBinding descriptorSetLayoutBindings[MAX_TEXTURE_SAMPLERS_PER_STAGE + MAX_STORAGE_TEXTURES_PER_STAGE + MAX_STORAGE_BUFFERS_PER_STAGE];
@@ -3586,15 +3586,15 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     VkResult vulkanResult;
     Uint32 i;
 
-    pipelineResourceLayout->vertexSamplerCount = vertex_shader->num_samplers;
-    pipelineResourceLayout->vertexStorageTextureCount = vertex_shader->num_storage_textures;
-    pipelineResourceLayout->vertexStorageBufferCount = vertex_shader->num_storage_buffers;
-    pipelineResourceLayout->vertexUniformBufferCount = vertex_shader->num_uniform_buffers;
+    pipelineResourceLayout->vertexSamplerCount = vertexShader->numSamplers;
+    pipelineResourceLayout->vertexStorageTextureCount = vertexShader->numStorageTextures;
+    pipelineResourceLayout->vertexStorageBufferCount = vertexShader->numStorageBuffers;
+    pipelineResourceLayout->vertexUniformBufferCount = vertexShader->numUniformBuffers;
 
-    pipelineResourceLayout->fragmentSamplerCount = fragment_shader->num_samplers;
-    pipelineResourceLayout->fragmentStorageTextureCount = fragment_shader->num_storage_textures;
-    pipelineResourceLayout->fragmentStorageBufferCount = fragment_shader->num_storage_buffers;
-    pipelineResourceLayout->fragmentUniformBufferCount = fragment_shader->num_uniform_buffers;
+    pipelineResourceLayout->fragmentSamplerCount = fragmentShader->numSamplers;
+    pipelineResourceLayout->fragmentStorageTextureCount = fragmentShader->numStorageTextures;
+    pipelineResourceLayout->fragmentStorageBufferCount = fragmentShader->numStorageBuffers;
+    pipelineResourceLayout->fragmentUniformBufferCount = fragmentShader->numUniformBuffers;
 
     // Vertex Resources
 
@@ -3603,9 +3603,9 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     descriptorSetLayoutCreateInfo.flags = 0;
     descriptorSetLayoutCreateInfo.pBindings = NULL;
     descriptorSetLayoutCreateInfo.bindingCount =
-        vertex_shader->num_samplers +
-        vertex_shader->num_storage_textures +
-        vertex_shader->num_storage_buffers;
+        vertexShader->numSamplers +
+        vertexShader->numStorageTextures +
+        vertexShader->numStorageBuffers;
 
     descriptorSetPool = &pipelineResourceLayout->descriptorSetPools[0];
 
@@ -3616,7 +3616,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < vertex_shader->num_samplers; i += 1) {
+        for (i = 0; i < vertexShader->numSamplers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -3627,7 +3627,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_VERTEX_BIT;
         }
 
-        for (i = vertex_shader->num_samplers; i < vertex_shader->num_samplers + vertex_shader->num_storage_textures; i += 1) {
+        for (i = vertexShader->numSamplers; i < vertexShader->numSamplers + vertexShader->numStorageTextures; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -3638,7 +3638,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_VERTEX_BIT;
         }
 
-        for (i = vertex_shader->num_samplers + vertex_shader->num_storage_textures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
+        for (i = vertexShader->numSamplers + vertexShader->numStorageTextures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -3679,7 +3679,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < vertex_shader->num_uniform_buffers; i += 1) {
+        for (i = 0; i < vertexShader->numUniformBuffers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -3711,9 +3711,9 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     descriptorSetPool = &pipelineResourceLayout->descriptorSetPools[2];
 
     descriptorSetLayoutCreateInfo.bindingCount =
-        fragment_shader->num_samplers +
-        fragment_shader->num_storage_textures +
-        fragment_shader->num_storage_buffers;
+        fragmentShader->numSamplers +
+        fragmentShader->numStorageTextures +
+        fragmentShader->numStorageBuffers;
 
     descriptorSetLayoutCreateInfo.pBindings = NULL;
 
@@ -3724,7 +3724,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < fragment_shader->num_samplers; i += 1) {
+        for (i = 0; i < fragmentShader->numSamplers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -3735,7 +3735,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_FRAGMENT_BIT;
         }
 
-        for (i = fragment_shader->num_samplers; i < fragment_shader->num_samplers + fragment_shader->num_storage_textures; i += 1) {
+        for (i = fragmentShader->numSamplers; i < fragmentShader->numSamplers + fragmentShader->numStorageTextures; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -3746,7 +3746,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_FRAGMENT_BIT;
         }
 
-        for (i = fragment_shader->num_samplers + fragment_shader->num_storage_textures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
+        for (i = fragmentShader->numSamplers + fragmentShader->numStorageTextures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -3789,7 +3789,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < fragment_shader->num_uniform_buffers; i += 1) {
+        for (i = 0; i < fragmentShader->numUniformBuffers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -3859,11 +3859,11 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
     VkResult vulkanResult;
     Uint32 i;
 
-    pipelineResourceLayout->num_readonly_storage_textures = createinfo->num_readonly_storage_textures;
-    pipelineResourceLayout->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
-    pipelineResourceLayout->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
-    pipelineResourceLayout->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
-    pipelineResourceLayout->num_uniform_buffers = createinfo->num_uniform_buffers;
+    pipelineResourceLayout->numReadonlyStorageTextures = createinfo->num_readonly_storage_textures;
+    pipelineResourceLayout->numReadonlyStorageBuffers = createinfo->num_readonly_storage_buffers;
+    pipelineResourceLayout->numWriteonlyStorageTextures = createinfo->num_writeonly_storage_textures;
+    pipelineResourceLayout->numWriteonlyStorageBuffers = createinfo->num_writeonly_storage_buffers;
+    pipelineResourceLayout->numUniformBuffers = createinfo->num_uniform_buffers;
 
     // Read-only resources
 
@@ -4053,7 +4053,7 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
 static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
     VulkanRenderer *renderer,
     VkDeviceSize size,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     VulkanBufferType type)
 {
     VulkanBuffer *buffer;
@@ -4062,21 +4062,21 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
     VkBufferUsageFlags vulkanUsageFlags = 0;
     Uint8 bindResult;
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
     }
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     }
 
-    if (usage_flags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
+    if (usageFlags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     }
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     }
 
@@ -4090,7 +4090,7 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
     buffer = SDL_malloc(sizeof(VulkanBuffer));
 
     buffer->size = size;
-    buffer->usage_flags = usage_flags;
+    buffer->usageFlags = usageFlags;
     buffer->type = type;
     buffer->markedForDestroy = 0;
     buffer->transitioned = false;
@@ -4142,7 +4142,7 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
 static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
     VulkanRenderer *renderer,
     VkDeviceSize size,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     VulkanBufferType type)
 {
     VulkanBufferHandle *bufferHandle;
@@ -4151,7 +4151,7 @@ static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
     buffer = VULKAN_INTERNAL_CreateBuffer(
         renderer,
         size,
-        usage_flags,
+        usageFlags,
         type);
 
     if (buffer == NULL) {
@@ -4171,7 +4171,7 @@ static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
 static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
     VulkanRenderer *renderer,
     VkDeviceSize size,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     VulkanBufferType type)
 {
     VulkanBufferContainer *bufferContainer;
@@ -4180,7 +4180,7 @@ static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
     bufferHandle = VULKAN_INTERNAL_CreateBufferHandle(
         renderer,
         size,
-        usage_flags,
+        usageFlags,
         type);
 
     if (bufferHandle == NULL) {
@@ -4206,11 +4206,11 @@ static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
 // Texture Subresource Utilities
 
 static Uint32 VULKAN_INTERNAL_GetTextureSubresourceIndex(
-    Uint32 mip_level,
+    Uint32 mipLevel,
     Uint32 layer,
     Uint32 numLevels)
 {
-    return mip_level + (layer * numLevels);
+    return mipLevel + (layer * numLevels);
 }
 
 static VulkanTextureSubresource *VULKAN_INTERNAL_FetchTextureSubresource(
@@ -4435,13 +4435,13 @@ static bool VULKAN_INTERNAL_VerifySwapSurfaceFormat(
 }
 
 static bool VULKAN_INTERNAL_VerifySwapPresentMode(
-    VkPresentModeKHR present_mode,
+    VkPresentModeKHR presentMode,
     VkPresentModeKHR *availablePresentModes,
     Uint32 availablePresentModesLength)
 {
     Uint32 i;
     for (i = 0; i < availablePresentModesLength; i += 1) {
-        if (availablePresentModes[i] == present_mode) {
+        if (availablePresentModes[i] == presentMode) {
             return true;
         }
     }
@@ -4461,17 +4461,17 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
     bool hasValidSwapchainComposition, hasValidPresentMode;
     Sint32 drawableWidth, drawableHeight;
     Uint32 i;
-    SDL_VideoDevice *_this = SDL_GetVideoDevice();
+    SDL_VideoDevice *this = SDL_GetVideoDevice();
 
-    SDL_assert(_this && _this->Vulkan_CreateSurface);
+    SDL_assert(this && this->Vulkan_CreateSurface);
 
     swapchainData = SDL_malloc(sizeof(VulkanSwapchainData));
     swapchainData->frameCounter = 0;
 
     // Each swapchain must have its own surface.
 
-    if (!_this->Vulkan_CreateSurface(
-            _this,
+    if (!this->Vulkan_CreateSurface(
+            this,
             windowData->window,
             renderer->instance,
             NULL, // FIXME: VAllocationCallbacks
@@ -4523,9 +4523,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
     // Verify that we can use the requested composition and present mode
 
-    swapchainData->format = SwapchainCompositionToFormat[windowData->swapchain_composition];
-    swapchainData->colorSpace = SwapchainCompositionToColorSpace[windowData->swapchain_composition];
-    swapchainData->swapchainSwizzle = SwapchainCompositionSwizzle[windowData->swapchain_composition];
+    swapchainData->format = SwapchainCompositionToFormat[windowData->swapchainComposition];
+    swapchainData->colorSpace = SwapchainCompositionToColorSpace[windowData->swapchainComposition];
+    swapchainData->swapchainSwizzle = SwapchainCompositionSwizzle[windowData->swapchainComposition];
     swapchainData->usingFallbackFormat = false;
 
     hasValidSwapchainComposition = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
@@ -4536,7 +4536,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
     if (!hasValidSwapchainComposition) {
         // Let's try again with the fallback format...
-        swapchainData->format = SwapchainCompositionToFallbackFormat[windowData->swapchain_composition];
+        swapchainData->format = SwapchainCompositionToFallbackFormat[windowData->swapchainComposition];
         swapchainData->usingFallbackFormat = true;
         hasValidSwapchainComposition = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
             swapchainData->format,
@@ -4545,9 +4545,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
             swapchainSupportDetails.formatsLength);
     }
 
-    swapchainData->present_mode = SDLToVK_PresentMode[windowData->present_mode];
+    swapchainData->presentMode = SDLToVK_PresentMode[windowData->presentMode];
     hasValidPresentMode = VULKAN_INTERNAL_VerifySwapPresentMode(
-        swapchainData->present_mode,
+        swapchainData->presentMode,
         swapchainSupportDetails.presentModes,
         swapchainSupportDetails.presentModesLength);
 
@@ -4624,7 +4624,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->imageCount = swapchainSupportDetails.capabilities.minImageCount;
     }
 
-    if (swapchainData->present_mode == VK_PRESENT_MODE_MAILBOX_KHR) {
+    if (swapchainData->presentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
         /* Required for proper triple-buffering.
          * Note that this is below the above maxImageCount check!
          * If the driver advertises MAILBOX but does not support 3 swap
@@ -4652,7 +4652,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
     swapchainCreateInfo.pQueueFamilyIndices = NULL;
     swapchainCreateInfo.preTransform = swapchainSupportDetails.capabilities.currentTransform;
     swapchainCreateInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-    swapchainCreateInfo.presentMode = swapchainData->present_mode;
+    swapchainCreateInfo.presentMode = swapchainData->presentMode;
     swapchainCreateInfo.clipped = VK_TRUE;
     swapchainCreateInfo.oldSwapchain = VK_NULL_HANDLE;
 
@@ -4714,7 +4714,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->textureContainers[i].header.info.height = drawableHeight;
         swapchainData->textureContainers[i].header.info.layer_count_or_depth = 1;
         swapchainData->textureContainers[i].header.info.format = SwapchainCompositionToSDLFormat(
-            windowData->swapchain_composition,
+            windowData->swapchainComposition,
             swapchainData->usingFallbackFormat);
         swapchainData->textureContainers[i].header.info.type = SDL_GPU_TEXTURETYPE_2D;
         swapchainData->textureContainers[i].header.info.num_levels = 1;
@@ -4737,9 +4737,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->type = SDL_GPU_TEXTURETYPE_2D;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->depth = 1;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->layerCount = 1;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->num_levels = 1;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->sample_count = VK_SAMPLE_COUNT_1_BIT;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->usage_flags =
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->numLevels = 1;
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->sampleCount = VK_SAMPLE_COUNT_1_BIT;
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->usageFlags =
             SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
         SDL_AtomicSet(&swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->referenceCount, 0);
@@ -4795,7 +4795,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
 static void VULKAN_INTERNAL_BeginCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     VkCommandBufferBeginInfo beginInfo;
     VkResult result;
@@ -4807,7 +4807,7 @@ static void VULKAN_INTERNAL_BeginCommandBuffer(
     beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 
     result = renderer->vkBeginCommandBuffer(
-        command_buffer->command_buffer,
+        commandBuffer->commandBuffer,
         &beginInfo);
 
     if (result != VK_SUCCESS) {
@@ -4817,12 +4817,12 @@ static void VULKAN_INTERNAL_BeginCommandBuffer(
 
 static void VULKAN_INTERNAL_EndCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     VkResult result;
 
     result = renderer->vkEndCommandBuffer(
-        command_buffer->command_buffer);
+        commandBuffer->commandBuffer);
 
     if (result != VK_SUCCESS) {
         LogVulkanResultAsError("vkEndCommandBuffer", result);
@@ -4993,7 +4993,7 @@ static VkDescriptorSet VULKAN_INTERNAL_FetchDescriptorSet(
 
 static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     VulkanGraphicsPipelineResourceLayout *resourceLayout;
     VkWriteDescriptorSet *writeDescriptorSets;
@@ -5006,14 +5006,14 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
     Uint32 imageInfoCount = 0;
     Uint32 i;
 
-    resourceLayout = &command_buffer->currentGraphicsPipeline->resourceLayout;
+    resourceLayout = &commandBuffer->currentGraphicsPipeline->resourceLayout;
 
-    if (command_buffer->needNewVertexResourceDescriptorSet) {
+    if (commandBuffer->needNewVertexResourceDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[0];
 
-        command_buffer->vertexResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->vertexResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5030,12 +5030,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
-            imageInfos[imageInfoCount].sampler = command_buffer->vertexSamplers[i]->sampler;
-            imageInfos[imageInfoCount].imageView = command_buffer->vertexSamplerTextures[i]->fullView;
+            imageInfos[imageInfoCount].sampler = commandBuffer->vertexSamplers[i]->sampler;
+            imageInfos[imageInfoCount].imageView = commandBuffer->vertexSamplerTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5052,12 +5052,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->vertexSamplerCount + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = command_buffer->vertexStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = commandBuffer->vertexStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5074,11 +5074,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->vertexSamplerCount + resourceLayout->vertexStorageTextureCount + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->vertexStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->vertexStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -5095,12 +5095,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             0,
             1,
-            &command_buffer->vertexResourceDescriptorSet,
+            &commandBuffer->vertexResourceDescriptorSet,
             0,
             NULL);
 
@@ -5108,15 +5108,15 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewVertexResourceDescriptorSet = false;
+        commandBuffer->needNewVertexResourceDescriptorSet = false;
     }
 
-    if (command_buffer->needNewVertexUniformDescriptorSet) {
+    if (commandBuffer->needNewVertexUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[1];
 
-        command_buffer->vertexUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->vertexUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5132,11 +5132,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->vertexUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->vertexUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->vertexUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->vertexUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -5156,34 +5156,34 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewVertexUniformDescriptorSet = false;
-        command_buffer->needNewVertexUniformOffsets = true;
+        commandBuffer->needNewVertexUniformDescriptorSet = false;
+        commandBuffer->needNewVertexUniformOffsets = true;
     }
 
-    if (command_buffer->needNewVertexUniformOffsets) {
+    if (commandBuffer->needNewVertexUniformOffsets) {
         for (i = 0; i < resourceLayout->vertexUniformBufferCount; i += 1) {
-            dynamicOffsets[i] = command_buffer->vertexUniformBuffers[i]->drawOffset;
+            dynamicOffsets[i] = commandBuffer->vertexUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             1,
             1,
-            &command_buffer->vertexUniformDescriptorSet,
+            &commandBuffer->vertexUniformDescriptorSet,
             resourceLayout->vertexUniformBufferCount,
             dynamicOffsets);
 
-        command_buffer->needNewVertexUniformOffsets = false;
+        commandBuffer->needNewVertexUniformOffsets = false;
     }
 
-    if (command_buffer->needNewFragmentResourceDescriptorSet) {
+    if (commandBuffer->needNewFragmentResourceDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[2];
 
-        command_buffer->fragmentResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->fragmentResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5200,12 +5200,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
-            imageInfos[imageInfoCount].sampler = command_buffer->fragmentSamplers[i]->sampler;
-            imageInfos[imageInfoCount].imageView = command_buffer->fragmentSamplerTextures[i]->fullView;
+            imageInfos[imageInfoCount].sampler = commandBuffer->fragmentSamplers[i]->sampler;
+            imageInfos[imageInfoCount].imageView = commandBuffer->fragmentSamplerTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5222,12 +5222,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->fragmentSamplerCount + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = command_buffer->fragmentStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = commandBuffer->fragmentStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5244,11 +5244,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->fragmentSamplerCount + resourceLayout->fragmentStorageTextureCount + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->fragmentStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->fragmentStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -5265,12 +5265,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             2,
             1,
-            &command_buffer->fragmentResourceDescriptorSet,
+            &commandBuffer->fragmentResourceDescriptorSet,
             0,
             NULL);
 
@@ -5278,15 +5278,15 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewFragmentResourceDescriptorSet = false;
+        commandBuffer->needNewFragmentResourceDescriptorSet = false;
     }
 
-    if (command_buffer->needNewFragmentUniformDescriptorSet) {
+    if (commandBuffer->needNewFragmentUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[3];
 
-        command_buffer->fragmentUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->fragmentUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5302,11 +5302,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->fragmentUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->fragmentUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->fragmentUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -5326,79 +5326,79 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewFragmentUniformDescriptorSet = false;
-        command_buffer->needNewFragmentUniformOffsets = true;
+        commandBuffer->needNewFragmentUniformDescriptorSet = false;
+        commandBuffer->needNewFragmentUniformOffsets = true;
     }
 
-    if (command_buffer->needNewFragmentUniformOffsets) {
+    if (commandBuffer->needNewFragmentUniformOffsets) {
         for (i = 0; i < resourceLayout->fragmentUniformBufferCount; i += 1) {
-            dynamicOffsets[i] = command_buffer->fragmentUniformBuffers[i]->drawOffset;
+            dynamicOffsets[i] = commandBuffer->fragmentUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             3,
             1,
-            &command_buffer->fragmentUniformDescriptorSet,
+            &commandBuffer->fragmentUniformDescriptorSet,
             resourceLayout->fragmentUniformBufferCount,
             dynamicOffsets);
 
-        command_buffer->needNewFragmentUniformOffsets = false;
+        commandBuffer->needNewFragmentUniformOffsets = false;
     }
 }
 
 static void VULKAN_DrawIndexedPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_indices,
-    Uint32 num_instances,
-    Uint32 first_index,
-    Sint32 vertex_offset,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numIndices,
+    Uint32 numInstances,
+    Uint32 firstIndex,
+    Sint32 vertexOffset,
+    Uint32 firstInstance)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindGraphicsDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDrawIndexed(
-        vulkanCommandBuffer->command_buffer,
-        num_indices,
-        num_instances,
-        first_index,
-        vertex_offset,
-        first_instance);
+        vulkanCommandBuffer->commandBuffer,
+        numIndices,
+        numInstances,
+        firstIndex,
+        vertexOffset,
+        firstInstance);
 }
 
 static void VULKAN_DrawPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_vertices,
-    Uint32 num_instances,
-    Uint32 first_vertex,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numVertices,
+    Uint32 numInstances,
+    Uint32 firstVertex,
+    Uint32 firstInstance)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindGraphicsDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDraw(
-        vulkanCommandBuffer->command_buffer,
-        num_vertices,
-        num_instances,
-        first_vertex,
-        first_instance);
+        vulkanCommandBuffer->commandBuffer,
+        numVertices,
+        numInstances,
+        firstVertex,
+        firstInstance);
 }
 
 static void VULKAN_DrawPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
     Uint32 i;
@@ -5408,16 +5408,16 @@ static void VULKAN_DrawPrimitivesIndirect(
     if (renderer->supportsMultiDrawIndirect) {
         // Real multi-draw!
         renderer->vkCmdDrawIndirect(
-            vulkanCommandBuffer->command_buffer,
+            vulkanCommandBuffer->commandBuffer,
             vulkanBuffer->buffer,
             offset,
-            draw_count,
+            drawCount,
             pitch);
     } else {
         // Fake multi-draw...
-        for (i = 0; i < draw_count; i += 1) {
+        for (i = 0; i < drawCount; i += 1) {
             renderer->vkCmdDrawIndirect(
-                vulkanCommandBuffer->command_buffer,
+                vulkanCommandBuffer->commandBuffer,
                 vulkanBuffer->buffer,
                 offset + (pitch * i),
                 1,
@@ -5429,13 +5429,13 @@ static void VULKAN_DrawPrimitivesIndirect(
 }
 
 static void VULKAN_DrawIndexedPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
     Uint32 i;
@@ -5445,16 +5445,16 @@ static void VULKAN_DrawIndexedPrimitivesIndirect(
     if (renderer->supportsMultiDrawIndirect) {
         // Real multi-draw!
         renderer->vkCmdDrawIndexedIndirect(
-            vulkanCommandBuffer->command_buffer,
+            vulkanCommandBuffer->commandBuffer,
             vulkanBuffer->buffer,
             offset,
-            draw_count,
+            drawCount,
             pitch);
     } else {
         // Fake multi-draw...
-        for (i = 0; i < draw_count; i += 1) {
+        for (i = 0; i < drawCount; i += 1) {
             renderer->vkCmdDrawIndexedIndirect(
-                vulkanCommandBuffer->command_buffer,
+                vulkanCommandBuffer->commandBuffer,
                 vulkanBuffer->buffer,
                 offset + (pitch * i),
                 1,
@@ -5474,7 +5474,7 @@ static void VULKAN_INTERNAL_SetBufferName(
 {
     VkDebugUtilsObjectNameInfoEXT nameInfo;
 
-    if (renderer->debug_mode && renderer->supportsDebugUtils) {
+    if (renderer->debugMode && renderer->supportsDebugUtils) {
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
         nameInfo.pObjectName = text;
@@ -5496,7 +5496,7 @@ static void VULKAN_SetBufferName(
     VulkanBufferContainer *container = (VulkanBufferContainer *)buffer;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debug_mode && renderer->supportsDebugUtils) {
+    if (renderer->debugMode && renderer->supportsDebugUtils) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -5522,7 +5522,7 @@ static void VULKAN_INTERNAL_SetTextureName(
 {
     VkDebugUtilsObjectNameInfoEXT nameInfo;
 
-    if (renderer->debug_mode && renderer->supportsDebugUtils) {
+    if (renderer->debugMode && renderer->supportsDebugUtils) {
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
         nameInfo.pObjectName = text;
@@ -5544,7 +5544,7 @@ static void VULKAN_SetTextureName(
     VulkanTextureContainer *container = (VulkanTextureContainer *)texture;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debug_mode && renderer->supportsDebugUtils) {
+    if (renderer->debugMode && renderer->supportsDebugUtils) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -5564,10 +5564,10 @@ static void VULKAN_SetTextureName(
 }
 
 static void VULKAN_InsertDebugLabel(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *text)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkDebugUtilsLabelEXT labelInfo;
 
@@ -5577,16 +5577,16 @@ static void VULKAN_InsertDebugLabel(
         labelInfo.pLabelName = text;
 
         renderer->vkCmdInsertDebugUtilsLabelEXT(
-            vulkanCommandBuffer->command_buffer,
+            vulkanCommandBuffer->commandBuffer,
             &labelInfo);
     }
 }
 
 static void VULKAN_PushDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *name)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkDebugUtilsLabelEXT labelInfo;
 
@@ -5596,19 +5596,19 @@ static void VULKAN_PushDebugGroup(
         labelInfo.pLabelName = name;
 
         renderer->vkCmdBeginDebugUtilsLabelEXT(
-            vulkanCommandBuffer->command_buffer,
+            vulkanCommandBuffer->commandBuffer,
             &labelInfo);
     }
 }
 
 static void VULKAN_PopDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     if (renderer->supportsDebugUtils) {
-        renderer->vkCmdEndDebugUtilsLabelEXT(vulkanCommandBuffer->command_buffer);
+        renderer->vkCmdEndDebugUtilsLabelEXT(vulkanCommandBuffer->commandBuffer);
     }
 }
 
@@ -5619,8 +5619,8 @@ static VulkanTextureHandle *VULKAN_INTERNAL_CreateTextureHandle(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 num_levels,
-    VkSampleCountFlagBits sample_count,
+    Uint32 numLevels,
+    VkSampleCountFlagBits sampleCount,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -5637,8 +5637,8 @@ static VulkanTextureHandle *VULKAN_INTERNAL_CreateTextureHandle(
         depth,
         type,
         layerCount,
-        num_levels,
-        sample_count,
+        numLevels,
+        sampleCount,
         format,
         swizzle,
         aspectMask,
@@ -5666,8 +5666,8 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 num_levels,
-    VkSampleCountFlagBits sample_count,
+    Uint32 numLevels,
+    VkSampleCountFlagBits sampleCount,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -5718,9 +5718,9 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     imageCreateInfo.extent.width = width;
     imageCreateInfo.extent.height = height;
     imageCreateInfo.extent.depth = depth;
-    imageCreateInfo.mipLevels = num_levels;
+    imageCreateInfo.mipLevels = numLevels;
     imageCreateInfo.arrayLayers = layerCount;
-    imageCreateInfo.samples = isMSAAColorTarget || VULKAN_INTERNAL_IsVulkanDepthFormat(format) ? sample_count : VK_SAMPLE_COUNT_1_BIT;
+    imageCreateInfo.samples = isMSAAColorTarget || VULKAN_INTERNAL_IsVulkanDepthFormat(format) ? sampleCount : VK_SAMPLE_COUNT_1_BIT;
     imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     imageCreateInfo.usage = vkUsageFlags;
     imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
@@ -5767,7 +5767,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
         imageViewCreateInfo.components = swizzle;
         imageViewCreateInfo.subresourceRange.aspectMask = aspectMask;
         imageViewCreateInfo.subresourceRange.baseMipLevel = 0;
-        imageViewCreateInfo.subresourceRange.levelCount = num_levels;
+        imageViewCreateInfo.subresourceRange.levelCount = numLevels;
         imageViewCreateInfo.subresourceRange.baseArrayLayer = 0;
         imageViewCreateInfo.subresourceRange.layerCount = layerCount;
 
@@ -5799,27 +5799,27 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     texture->depth = depth;
     texture->format = format;
     texture->swizzle = swizzle;
-    texture->num_levels = num_levels;
+    texture->numLevels = numLevels;
     texture->layerCount = layerCount;
-    texture->sample_count = sample_count;
-    texture->usage_flags = textureUsageFlags;
+    texture->sampleCount = sampleCount;
+    texture->usageFlags = textureUsageFlags;
     texture->aspectFlags = aspectMask;
     SDL_AtomicSet(&texture->referenceCount, 0);
 
     // Define slices
     texture->subresourceCount =
         texture->layerCount *
-        texture->num_levels;
+        texture->numLevels;
 
     texture->subresources = SDL_malloc(
         texture->subresourceCount * sizeof(VulkanTextureSubresource));
 
     for (Uint32 i = 0; i < texture->layerCount; i += 1) {
-        for (Uint32 j = 0; j < texture->num_levels; j += 1) {
+        for (Uint32 j = 0; j < texture->numLevels; j += 1) {
             Uint32 subresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 j,
                 i,
-                texture->num_levels);
+                texture->numLevels);
 
             texture->subresources[subresourceIndex].renderTargetViews = NULL;
             texture->subresources[subresourceIndex].computeWriteView = VK_NULL_HANDLE;
@@ -5877,7 +5877,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
             texture->subresources[subresourceIndex].transitioned = false;
 
             if (
-                sample_count > VK_SAMPLE_COUNT_1_BIT &&
+                sampleCount > VK_SAMPLE_COUNT_1_BIT &&
                 isRenderTarget &&
                 !isMSAAColorTarget &&
                 !VULKAN_INTERNAL_IsVulkanDepthFormat(texture->format)) {
@@ -5889,7 +5889,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
                     0,
                     1,
                     1,
-                    sample_count,
+                    sampleCount,
                     texture->format,
                     texture->swizzle,
                     aspectMask,
@@ -5922,7 +5922,7 @@ static void VULKAN_INTERNAL_CycleActiveBuffer(
     bufferContainer->activeBufferHandle = VULKAN_INTERNAL_CreateBufferHandle(
         renderer,
         bufferContainer->activeBufferHandle->vulkanBuffer->size,
-        bufferContainer->activeBufferHandle->vulkanBuffer->usage_flags,
+        bufferContainer->activeBufferHandle->vulkanBuffer->usageFlags,
         bufferContainer->activeBufferHandle->vulkanBuffer->type);
 
     bufferContainer->activeBufferHandle->container = bufferContainer;
@@ -5938,7 +5938,7 @@ static void VULKAN_INTERNAL_CycleActiveBuffer(
     bufferContainer->bufferCount += 1;
 
     if (
-        renderer->debug_mode &&
+        renderer->debugMode &&
         renderer->supportsDebugUtils &&
         bufferContainer->debugName != NULL) {
         VULKAN_INTERNAL_SetBufferName(
@@ -5970,12 +5970,12 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
         textureContainer->activeTextureHandle->vulkanTexture->depth,
         textureContainer->activeTextureHandle->vulkanTexture->type,
         textureContainer->activeTextureHandle->vulkanTexture->layerCount,
-        textureContainer->activeTextureHandle->vulkanTexture->num_levels,
-        textureContainer->activeTextureHandle->vulkanTexture->sample_count,
+        textureContainer->activeTextureHandle->vulkanTexture->numLevels,
+        textureContainer->activeTextureHandle->vulkanTexture->sampleCount,
         textureContainer->activeTextureHandle->vulkanTexture->format,
         textureContainer->activeTextureHandle->vulkanTexture->swizzle,
         textureContainer->activeTextureHandle->vulkanTexture->aspectFlags,
-        textureContainer->activeTextureHandle->vulkanTexture->usage_flags,
+        textureContainer->activeTextureHandle->vulkanTexture->usageFlags,
         false);
 
     textureContainer->activeTextureHandle->container = textureContainer;
@@ -5991,7 +5991,7 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
     textureContainer->textureCount += 1;
 
     if (
-        renderer->debug_mode &&
+        renderer->debugMode &&
         renderer->supportsDebugUtils &&
         textureContainer->debugName != NULL) {
         VULKAN_INTERNAL_SetTextureName(
@@ -6003,7 +6003,7 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
 
 static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBufferContainer *bufferContainer,
     bool cycle,
     VulkanBufferUsageMode destinationUsageMode)
@@ -6018,7 +6018,7 @@ static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
 
     VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
         renderer,
-        command_buffer,
+        commandBuffer,
         destinationUsageMode,
         bufferContainer->activeBufferHandle->vulkanBuffer);
 
@@ -6027,7 +6027,7 @@ static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
 
 static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureContainer *textureContainer,
     Uint32 layer,
     Uint32 level,
@@ -6056,7 +6056,7 @@ static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWri
     // always do barrier because of layout transitions
     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
         renderer,
-        command_buffer,
+        commandBuffer,
         destinationUsageMode,
         textureSubresource);
 
@@ -6065,10 +6065,10 @@ static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWri
 
 static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    VulkanCommandBuffer *commandBuffer,
+    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
+    Uint32 numColorAttachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
 {
     VkResult vulkanResult;
     VkAttachmentDescription attachmentDescriptions[2 * MAX_COLOR_TARGET_BINDINGS + 1];
@@ -6077,7 +6077,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     VkAttachmentReference depthStencilAttachmentReference;
     VkRenderPassCreateInfo renderPassCreateInfo;
     VkSubpassDescription subpass;
-    VkRenderPass render_pass;
+    VkRenderPass renderPass;
     Uint32 i;
 
     Uint32 attachmentDescriptionCount = 0;
@@ -6086,17 +6086,17 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
 
     VulkanTexture *texture = NULL;
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        texture = ((VulkanTextureContainer *)color_attachment_infos[i].texture)->activeTextureHandle->vulkanTexture;
+    for (i = 0; i < numColorAttachments; i += 1) {
+        texture = ((VulkanTextureContainer *)colorAttachmentInfos[i].texture)->activeTextureHandle->vulkanTexture;
 
-        if (texture->sample_count > VK_SAMPLE_COUNT_1_BIT) {
+        if (texture->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
             // Resolve attachment and multisample attachment
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
             attachmentDescriptions[attachmentDescriptionCount].samples =
                 VK_SAMPLE_COUNT_1_BIT;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorAttachmentInfos[i].load_op];
             attachmentDescriptions[attachmentDescriptionCount].storeOp =
                 VK_ATTACHMENT_STORE_OP_STORE; // Always store the resolve texture
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
@@ -6118,9 +6118,9 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
-            attachmentDescriptions[attachmentDescriptionCount].samples = texture->sample_count;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
-            attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[color_attachment_infos[i].store_op];
+            attachmentDescriptions[attachmentDescriptionCount].samples = texture->sampleCount;
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorAttachmentInfos[i].load_op];
+            attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[colorAttachmentInfos[i].store_op];
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
                 VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp =
@@ -6142,7 +6142,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
             attachmentDescriptions[attachmentDescriptionCount].samples =
                 VK_SAMPLE_COUNT_1_BIT;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorAttachmentInfos[i].load_op];
             attachmentDescriptions[attachmentDescriptionCount].storeOp =
                 VK_ATTACHMENT_STORE_OP_STORE; // Always store non-MSAA textures
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
@@ -6167,24 +6167,24 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
     subpass.pInputAttachments = NULL;
-    subpass.colorAttachmentCount = num_color_attachments;
+    subpass.colorAttachmentCount = numColorAttachments;
     subpass.pColorAttachments = colorAttachmentReferences;
     subpass.preserveAttachmentCount = 0;
     subpass.pPreserveAttachments = NULL;
 
-    if (depth_stencil_attachment_info == NULL) {
+    if (depthStencilAttachmentInfo == NULL) {
         subpass.pDepthStencilAttachment = NULL;
     } else {
-        texture = ((VulkanTextureContainer *)depth_stencil_attachment_info->texture)->activeTextureHandle->vulkanTexture;
+        texture = ((VulkanTextureContainer *)depthStencilAttachmentInfo->texture)->activeTextureHandle->vulkanTexture;
 
         attachmentDescriptions[attachmentDescriptionCount].flags = 0;
         attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
-        attachmentDescriptions[attachmentDescriptionCount].samples = texture->sample_count;
+        attachmentDescriptions[attachmentDescriptionCount].samples = texture->sampleCount;
 
-        attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[depth_stencil_attachment_info->load_op];
-        attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[depth_stencil_attachment_info->store_op];
-        attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp = SDLToVK_LoadOp[depth_stencil_attachment_info->stencil_load_op];
-        attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp = SDLToVK_StoreOp[depth_stencil_attachment_info->stencil_store_op];
+        attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[depthStencilAttachmentInfo->load_op];
+        attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[depthStencilAttachmentInfo->store_op];
+        attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp = SDLToVK_LoadOp[depthStencilAttachmentInfo->stencil_load_op];
+        attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp = SDLToVK_StoreOp[depthStencilAttachmentInfo->stencil_store_op];
         attachmentDescriptions[attachmentDescriptionCount].initialLayout =
             VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
         attachmentDescriptions[attachmentDescriptionCount].finalLayout =
@@ -6201,7 +6201,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
         attachmentDescriptionCount += 1;
     }
 
-    if (texture != NULL && texture->sample_count > VK_SAMPLE_COUNT_1_BIT) {
+    if (texture != NULL && texture->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
         subpass.pResolveAttachments = resolveReferences;
     } else {
         subpass.pResolveAttachments = NULL;
@@ -6221,20 +6221,20 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
         renderer->logicalDevice,
         &renderPassCreateInfo,
         NULL,
-        &render_pass);
+        &renderPass);
 
     if (vulkanResult != VK_SUCCESS) {
-        render_pass = VK_NULL_HANDLE;
+        renderPass = VK_NULL_HANDLE;
         LogVulkanResultAsError("vkCreateRenderPass", vulkanResult);
     }
 
-    return render_pass;
+    return renderPass;
 }
 
 static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     VulkanRenderer *renderer,
-    SDL_GPUGraphicsPipelineAttachmentInfo attachment_info,
-    VkSampleCountFlagBits sample_count)
+    SDL_GPUGraphicsPipelineAttachmentInfo attachmentInfo,
+    VkSampleCountFlagBits sampleCount)
 {
     VkAttachmentDescription attachmentDescriptions[2 * MAX_COLOR_TARGET_BINDINGS + 1];
     VkAttachmentReference colorAttachmentReferences[MAX_COLOR_TARGET_BINDINGS];
@@ -6243,7 +6243,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     SDL_GPUColorAttachmentDescription attachmentDescription;
     VkSubpassDescription subpass;
     VkRenderPassCreateInfo renderPassCreateInfo;
-    VkRenderPass render_pass;
+    VkRenderPass renderPass;
     VkResult result;
 
     Uint32 multisampling = 0;
@@ -6252,10 +6252,10 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     Uint32 resolveReferenceCount = 0;
     Uint32 i;
 
-    for (i = 0; i < attachment_info.num_color_attachments; i += 1) {
-        attachmentDescription = attachment_info.color_attachment_descriptions[i];
+    for (i = 0; i < attachmentInfo.num_color_attachments; i += 1) {
+        attachmentDescription = attachmentInfo.color_attachment_descriptions[i];
 
-        if (sample_count > VK_SAMPLE_COUNT_1_BIT) {
+        if (sampleCount > VK_SAMPLE_COUNT_1_BIT) {
             multisampling = 1;
 
             // Resolve attachment and multisample attachment
@@ -6278,7 +6278,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = SDLToVK_SurfaceFormat[attachmentDescription.format];
-            attachmentDescriptions[attachmentDescriptionCount].samples = sample_count;
+            attachmentDescriptions[attachmentDescriptionCount].samples = sampleCount;
 
             attachmentDescriptions[attachmentDescriptionCount].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             attachmentDescriptions[attachmentDescriptionCount].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -6325,16 +6325,16 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
     subpass.pInputAttachments = NULL;
-    subpass.colorAttachmentCount = attachment_info.num_color_attachments;
+    subpass.colorAttachmentCount = attachmentInfo.num_color_attachments;
     subpass.pColorAttachments = colorAttachmentReferences;
     subpass.preserveAttachmentCount = 0;
     subpass.pPreserveAttachments = NULL;
 
-    if (attachment_info.has_depth_stencil_attachment) {
+    if (attachmentInfo.has_depth_stencil_attachment) {
         attachmentDescriptions[attachmentDescriptionCount].flags = 0;
         attachmentDescriptions[attachmentDescriptionCount].format =
-            SDLToVK_SurfaceFormat[attachment_info.depth_stencil_format];
-        attachmentDescriptions[attachmentDescriptionCount].samples = sample_count;
+            SDLToVK_SurfaceFormat[attachmentInfo.depth_stencil_format];
+        attachmentDescriptions[attachmentDescriptionCount].samples = sampleCount;
 
         attachmentDescriptions[attachmentDescriptionCount].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         attachmentDescriptions[attachmentDescriptionCount].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -6378,14 +6378,14 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
         renderer->logicalDevice,
         &renderPassCreateInfo,
         NULL,
-        &render_pass);
+        &renderPass);
 
     if (result != VK_SUCCESS) {
-        render_pass = VK_NULL_HANDLE;
+        renderPass = VK_NULL_HANDLE;
         LogVulkanResultAsError("vkCreateRenderPass", result);
     }
 
-    return render_pass;
+    return renderPass;
 }
 
 static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
@@ -6396,7 +6396,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     Uint32 i;
     VkSampleCountFlagBits actualSampleCount;
 
-    VulkanGraphicsPipeline *graphics_pipeline = (VulkanGraphicsPipeline *)SDL_malloc(sizeof(VulkanGraphicsPipeline));
+    VulkanGraphicsPipeline *graphicsPipeline = (VulkanGraphicsPipeline *)SDL_malloc(sizeof(VulkanGraphicsPipeline));
     VkGraphicsPipelineCreateInfo vkPipelineCreateInfo;
 
     VkPipelineShaderStageCreateInfo shaderStageCreateInfos[2];
@@ -6417,8 +6417,8 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     VkPipelineMultisampleStateCreateInfo multisampleStateCreateInfo;
 
     VkPipelineDepthStencilStateCreateInfo depthStencilStateCreateInfo;
-    VkStencilOpState front_stencil_state;
-    VkStencilOpState back_stencil_state;
+    VkStencilOpState frontStencilState;
+    VkStencilOpState backStencilState;
 
     VkPipelineColorBlendStateCreateInfo colorBlendStateCreateInfo;
     VkPipelineColorBlendAttachmentState *colorBlendAttachmentStates = SDL_stack_alloc(
@@ -6458,26 +6458,26 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     // Shader stages
 
-    graphics_pipeline->vertex_shader = (VulkanShader *)createinfo->vertex_shader;
-    SDL_AtomicIncRef(&graphics_pipeline->vertex_shader->referenceCount);
+    graphicsPipeline->vertexShader = (VulkanShader *)createinfo->vertex_shader;
+    SDL_AtomicIncRef(&graphicsPipeline->vertexShader->referenceCount);
 
     shaderStageCreateInfos[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStageCreateInfos[0].pNext = NULL;
     shaderStageCreateInfos[0].flags = 0;
     shaderStageCreateInfos[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStageCreateInfos[0].module = graphics_pipeline->vertex_shader->shaderModule;
-    shaderStageCreateInfos[0].pName = graphics_pipeline->vertex_shader->entrypoint_name;
+    shaderStageCreateInfos[0].module = graphicsPipeline->vertexShader->shaderModule;
+    shaderStageCreateInfos[0].pName = graphicsPipeline->vertexShader->entrypointName;
     shaderStageCreateInfos[0].pSpecializationInfo = NULL;
 
-    graphics_pipeline->fragment_shader = (VulkanShader *)createinfo->fragment_shader;
-    SDL_AtomicIncRef(&graphics_pipeline->fragment_shader->referenceCount);
+    graphicsPipeline->fragmentShader = (VulkanShader *)createinfo->fragment_shader;
+    SDL_AtomicIncRef(&graphicsPipeline->fragmentShader->referenceCount);
 
     shaderStageCreateInfos[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStageCreateInfos[1].pNext = NULL;
     shaderStageCreateInfos[1].flags = 0;
     shaderStageCreateInfos[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStageCreateInfos[1].module = graphics_pipeline->fragment_shader->shaderModule;
-    shaderStageCreateInfos[1].pName = graphics_pipeline->fragment_shader->entrypoint_name;
+    shaderStageCreateInfos[1].module = graphicsPipeline->fragmentShader->shaderModule;
+    shaderStageCreateInfos[1].pName = graphicsPipeline->fragmentShader->entrypointName;
     shaderStageCreateInfos[1].pSpecializationInfo = NULL;
 
     // Vertex input
@@ -6535,7 +6535,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     inputAssemblyStateCreateInfo.primitiveRestartEnable = VK_FALSE;
     inputAssemblyStateCreateInfo.topology = SDLToVK_PrimitiveType[createinfo->primitive_type];
 
-    graphics_pipeline->primitive_type = createinfo->primitive_type;
+    graphicsPipeline->primitiveType = createinfo->primitive_type;
 
     // Viewport
 
@@ -6586,25 +6586,25 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     // Depth Stencil State
 
-    front_stencil_state.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.fail_op];
-    front_stencil_state.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.pass_op];
-    front_stencil_state.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.depth_fail_op];
-    front_stencil_state.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.front_stencil_state.compare_op];
-    front_stencil_state.compareMask =
+    frontStencilState.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.fail_op];
+    frontStencilState.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.pass_op];
+    frontStencilState.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.depth_fail_op];
+    frontStencilState.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.front_stencil_state.compare_op];
+    frontStencilState.compareMask =
         createinfo->depth_stencil_state.compare_mask;
-    front_stencil_state.writeMask =
+    frontStencilState.writeMask =
         createinfo->depth_stencil_state.write_mask;
-    front_stencil_state.reference = 0;
+    frontStencilState.reference = 0;
 
-    back_stencil_state.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.fail_op];
-    back_stencil_state.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.pass_op];
-    back_stencil_state.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.depth_fail_op];
-    back_stencil_state.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.back_stencil_state.compare_op];
-    back_stencil_state.compareMask =
+    backStencilState.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.fail_op];
+    backStencilState.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.pass_op];
+    backStencilState.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.depth_fail_op];
+    backStencilState.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.back_stencil_state.compare_op];
+    backStencilState.compareMask =
         createinfo->depth_stencil_state.compare_mask;
-    back_stencil_state.writeMask =
+    backStencilState.writeMask =
         createinfo->depth_stencil_state.write_mask;
-    back_stencil_state.reference = 0;
+    backStencilState.reference = 0;
 
     depthStencilStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
     depthStencilStateCreateInfo.pNext = NULL;
@@ -6617,26 +6617,26 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     depthStencilStateCreateInfo.depthBoundsTestEnable = VK_FALSE;
     depthStencilStateCreateInfo.stencilTestEnable =
         createinfo->depth_stencil_state.enable_stencil_test;
-    depthStencilStateCreateInfo.front = front_stencil_state;
-    depthStencilStateCreateInfo.back = back_stencil_state;
+    depthStencilStateCreateInfo.front = frontStencilState;
+    depthStencilStateCreateInfo.back = backStencilState;
     depthStencilStateCreateInfo.minDepthBounds = 0; // unused
     depthStencilStateCreateInfo.maxDepthBounds = 0; // unused
 
     // Color Blend
 
     for (i = 0; i < createinfo->attachment_info.num_color_attachments; i += 1) {
-        SDL_GPUColorAttachmentBlendState blend_state = createinfo->attachment_info.color_attachment_descriptions[i].blend_state;
+        SDL_GPUColorAttachmentBlendState blendState = createinfo->attachment_info.color_attachment_descriptions[i].blend_state;
 
         colorBlendAttachmentStates[i].blendEnable =
-            blend_state.enable_blend;
-        colorBlendAttachmentStates[i].srcColorBlendFactor = SDLToVK_BlendFactor[blend_state.src_color_blendfactor];
-        colorBlendAttachmentStates[i].dstColorBlendFactor = SDLToVK_BlendFactor[blend_state.dst_color_blendfactor];
-        colorBlendAttachmentStates[i].colorBlendOp = SDLToVK_BlendOp[blend_state.color_blend_op];
-        colorBlendAttachmentStates[i].srcAlphaBlendFactor = SDLToVK_BlendFactor[blend_state.src_alpha_blendfactor];
-        colorBlendAttachmentStates[i].dstAlphaBlendFactor = SDLToVK_BlendFactor[blend_state.dst_alpha_blendfactor];
-        colorBlendAttachmentStates[i].alphaBlendOp = SDLToVK_BlendOp[blend_state.alpha_blend_op];
+            blendState.enable_blend;
+        colorBlendAttachmentStates[i].srcColorBlendFactor = SDLToVK_BlendFactor[blendState.src_color_blendfactor];
+        colorBlendAttachmentStates[i].dstColorBlendFactor = SDLToVK_BlendFactor[blendState.dst_color_blendfactor];
+        colorBlendAttachmentStates[i].colorBlendOp = SDLToVK_BlendOp[blendState.color_blend_op];
+        colorBlendAttachmentStates[i].srcAlphaBlendFactor = SDLToVK_BlendFactor[blendState.src_alpha_blendfactor];
+        colorBlendAttachmentStates[i].dstAlphaBlendFactor = SDLToVK_BlendFactor[blendState.dst_alpha_blendfactor];
+        colorBlendAttachmentStates[i].alphaBlendOp = SDLToVK_BlendOp[blendState.alpha_blend_op];
         colorBlendAttachmentStates[i].colorWriteMask =
-            blend_state.color_write_mask;
+            blendState.color_write_mask;
     }
 
     colorBlendStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
@@ -6659,14 +6659,14 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     if (!VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             renderer,
-            graphics_pipeline->vertex_shader,
-            graphics_pipeline->fragment_shader,
-            &graphics_pipeline->resourceLayout)) {
+            graphicsPipeline->vertexShader,
+            graphicsPipeline->fragmentShader,
+            &graphicsPipeline->resourceLayout)) {
         SDL_stack_free(vertexInputBindingDescriptions);
         SDL_stack_free(vertexInputAttributeDescriptions);
         SDL_stack_free(colorBlendAttachmentStates);
         SDL_stack_free(divisorDescriptions);
-        SDL_free(graphics_pipeline);
+        SDL_free(graphicsPipeline);
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to initialize pipeline resource layout!");
         return NULL;
     }
@@ -6687,7 +6687,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     vkPipelineCreateInfo.pDepthStencilState = &depthStencilStateCreateInfo;
     vkPipelineCreateInfo.pColorBlendState = &colorBlendStateCreateInfo;
     vkPipelineCreateInfo.pDynamicState = &dynamicStateCreateInfo;
-    vkPipelineCreateInfo.layout = graphics_pipeline->resourceLayout.pipelineLayout;
+    vkPipelineCreateInfo.layout = graphicsPipeline->resourceLayout.pipelineLayout;
     vkPipelineCreateInfo.renderPass = transientRenderPass;
     vkPipelineCreateInfo.subpass = 0;
     vkPipelineCreateInfo.basePipelineHandle = VK_NULL_HANDLE;
@@ -6700,7 +6700,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
         1,
         &vkPipelineCreateInfo,
         NULL,
-        &graphics_pipeline->pipeline);
+        &graphicsPipeline->pipeline);
 
     SDL_stack_free(vertexInputBindingDescriptions);
     SDL_stack_free(vertexInputAttributeDescriptions);
@@ -6713,15 +6713,15 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
         NULL);
 
     if (vulkanResult != VK_SUCCESS) {
-        SDL_free(graphics_pipeline);
+        SDL_free(graphicsPipeline);
         LogVulkanResultAsError("vkCreateGraphicsPipelines", vulkanResult);
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create graphics pipeline!");
         return NULL;
     }
 
-    SDL_AtomicSet(&graphics_pipeline->referenceCount, 0);
+    SDL_AtomicSet(&graphicsPipeline->referenceCount, 0);
 
-    return (SDL_GPUGraphicsPipeline *)graphics_pipeline;
+    return (SDL_GPUGraphicsPipeline *)graphicsPipeline;
 }
 
 static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
@@ -6901,13 +6901,13 @@ static SDL_GPUShader *VULKAN_CreateShader(
     }
 
     entryPointNameLength = SDL_strlen(createinfo->entrypoint_name) + 1;
-    vulkanShader->entrypoint_name = SDL_malloc(entryPointNameLength);
-    SDL_utf8strlcpy((char *)vulkanShader->entrypoint_name, createinfo->entrypoint_name, entryPointNameLength);
+    vulkanShader->entrypointName = SDL_malloc(entryPointNameLength);
+    SDL_utf8strlcpy((char *)vulkanShader->entrypointName, createinfo->entrypoint_name, entryPointNameLength);
 
-    vulkanShader->num_samplers = createinfo->num_samplers;
-    vulkanShader->num_storage_textures = createinfo->num_storage_textures;
-    vulkanShader->num_storage_buffers = createinfo->num_storage_buffers;
-    vulkanShader->num_uniform_buffers = createinfo->num_uniform_buffers;
+    vulkanShader->numSamplers = createinfo->num_samplers;
+    vulkanShader->numStorageTextures = createinfo->num_storage_textures;
+    vulkanShader->numStorageBuffers = createinfo->num_storage_buffers;
+    vulkanShader->numUniformBuffers = createinfo->num_uniform_buffers;
 
     SDL_AtomicSet(&vulkanShader->referenceCount, 0);
 
@@ -6917,11 +6917,11 @@ static SDL_GPUShader *VULKAN_CreateShader(
 static bool VULKAN_SupportsSampleCount(
     SDL_GPURenderer *driverData,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sample_count)
+    SDL_GPUSampleCount sampleCount)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     VkSampleCountFlags bits = IsDepthFormat(format) ? renderer->physicalDeviceProperties.properties.limits.framebufferDepthSampleCounts : renderer->physicalDeviceProperties.properties.limits.framebufferColorSampleCounts;
-    VkSampleCountFlagBits vkSampleCount = SDLToVK_SampleCount[sample_count];
+    VkSampleCountFlagBits vkSampleCount = SDLToVK_SampleCount[sampleCount];
     return !!(bits & vkSampleCount);
 }
 
@@ -6988,13 +6988,13 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
 
 static SDL_GPUBuffer *VULKAN_CreateBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     Uint32 size)
 {
     return (SDL_GPUBuffer *)VULKAN_INTERNAL_CreateBufferContainer(
         (VulkanRenderer *)driverData,
         (VkDeviceSize)size,
-        usage_flags,
+        usageFlags,
         VULKAN_BUFFER_TYPE_GPU);
 }
 
@@ -7162,10 +7162,10 @@ static void VULKAN_ReleaseBuffer(
 
 static void VULKAN_ReleaseTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transfer_buffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
 
     VULKAN_INTERNAL_ReleaseBufferContainer(
         renderer,
@@ -7196,10 +7196,10 @@ static void VULKAN_ReleaseShader(
 
 static void VULKAN_ReleaseComputePipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUComputePipeline *computePipeline)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)compute_pipeline;
+    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)computePipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -7218,10 +7218,10 @@ static void VULKAN_ReleaseComputePipeline(
 
 static void VULKAN_ReleaseGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanGraphicsPipeline *vulkanGraphicsPipeline = (VulkanGraphicsPipeline *)graphics_pipeline;
+    VulkanGraphicsPipeline *vulkanGraphicsPipeline = (VulkanGraphicsPipeline *)graphicsPipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -7242,41 +7242,41 @@ static void VULKAN_ReleaseGraphicsPipeline(
 
 static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    VulkanCommandBuffer *commandBuffer,
+    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
+    Uint32 numColorAttachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
 {
     VulkanRenderPassHashTableValue *renderPassWrapper = NULL;
     VkRenderPass renderPassHandle;
     RenderPassHashTableKey key;
     Uint32 i;
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        key.colorTargetDescriptions[i].format = ((VulkanTextureContainer *)color_attachment_infos[i].texture)->activeTextureHandle->vulkanTexture->format;
-        key.colorTargetDescriptions[i].load_op = color_attachment_infos[i].load_op;
-        key.colorTargetDescriptions[i].store_op = color_attachment_infos[i].store_op;
+    for (i = 0; i < numColorAttachments; i += 1) {
+        key.colorTargetDescriptions[i].format = ((VulkanTextureContainer *)colorAttachmentInfos[i].texture)->activeTextureHandle->vulkanTexture->format;
+        key.colorTargetDescriptions[i].loadOp = colorAttachmentInfos[i].load_op;
+        key.colorTargetDescriptions[i].storeOp = colorAttachmentInfos[i].store_op;
     }
 
     key.colorAttachmentSampleCount = VK_SAMPLE_COUNT_1_BIT;
-    if (num_color_attachments > 0) {
-        key.colorAttachmentSampleCount = ((VulkanTextureContainer *)color_attachment_infos[0].texture)->activeTextureHandle->vulkanTexture->sample_count;
+    if (numColorAttachments > 0) {
+        key.colorAttachmentSampleCount = ((VulkanTextureContainer *)colorAttachmentInfos[0].texture)->activeTextureHandle->vulkanTexture->sampleCount;
     }
 
-    key.num_color_attachments = num_color_attachments;
+    key.numColorAttachments = numColorAttachments;
 
-    if (depth_stencil_attachment_info == NULL) {
+    if (depthStencilAttachmentInfo == NULL) {
         key.depthStencilTargetDescription.format = 0;
-        key.depthStencilTargetDescription.load_op = SDL_GPU_LOADOP_DONT_CARE;
-        key.depthStencilTargetDescription.store_op = SDL_GPU_STOREOP_DONT_CARE;
-        key.depthStencilTargetDescription.stencil_load_op = SDL_GPU_LOADOP_DONT_CARE;
-        key.depthStencilTargetDescription.stencil_store_op = SDL_GPU_STOREOP_DONT_CARE;
+        key.depthStencilTargetDescription.loadOp = SDL_GPU_LOADOP_DONT_CARE;
+        key.depthStencilTargetDescription.storeOp = SDL_GPU_STOREOP_DONT_CARE;
+        key.depthStencilTargetDescription.stencilLoadOp = SDL_GPU_LOADOP_DONT_CARE;
+        key.depthStencilTargetDescription.stencilStoreOp = SDL_GPU_STOREOP_DONT_CARE;
     } else {
-        key.depthStencilTargetDescription.format = ((VulkanTextureContainer *)depth_stencil_attachment_info->texture)->activeTextureHandle->vulkanTexture->format;
-        key.depthStencilTargetDescription.load_op = depth_stencil_attachment_info->load_op;
-        key.depthStencilTargetDescription.store_op = depth_stencil_attachment_info->store_op;
-        key.depthStencilTargetDescription.stencil_load_op = depth_stencil_attachment_info->stencil_load_op;
-        key.depthStencilTargetDescription.stencil_store_op = depth_stencil_attachment_info->stencil_store_op;
+        key.depthStencilTargetDescription.format = ((VulkanTextureContainer *)depthStencilAttachmentInfo->texture)->activeTextureHandle->vulkanTexture->format;
+        key.depthStencilTargetDescription.loadOp = depthStencilAttachmentInfo->load_op;
+        key.depthStencilTargetDescription.storeOp = depthStencilAttachmentInfo->store_op;
+        key.depthStencilTargetDescription.stencilLoadOp = depthStencilAttachmentInfo->stencil_load_op;
+        key.depthStencilTargetDescription.stencilStoreOp = depthStencilAttachmentInfo->stencil_store_op;
     }
 
     SDL_LockMutex(renderer->renderPassFetchLock);
@@ -7294,10 +7294,10 @@ static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
 
     renderPassHandle = VULKAN_INTERNAL_CreateRenderPass(
         renderer,
-        command_buffer,
-        color_attachment_infos,
-        num_color_attachments,
-        depth_stencil_attachment_info);
+        commandBuffer,
+        colorAttachmentInfos,
+        numColorAttachments,
+        depthStencilAttachmentInfo);
 
     if (renderPassHandle == VK_NULL_HANDLE) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create VkRenderPass!");
@@ -7324,10 +7324,10 @@ static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
 
 static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
     VulkanRenderer *renderer,
-    VkRenderPass render_pass,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info,
+    VkRenderPass renderPass,
+    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
+    Uint32 numColorAttachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo,
     Uint32 width,
     Uint32 height)
 {
@@ -7344,17 +7344,17 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         key.colorMultiSampleAttachmentViews[i] = VK_NULL_HANDLE;
     }
 
-    key.num_color_attachments = num_color_attachments;
+    key.numColorAttachments = numColorAttachments;
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+    for (i = 0; i < numColorAttachments; i += 1) {
+        VulkanTextureContainer *container = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layer_or_depth_plane,
+            colorAttachmentInfos[i].mip_level);
 
         Uint32 rtvIndex =
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layer_or_depth_plane : 0;
         key.colorAttachmentViews[i] = subresource->renderTargetViews[rtvIndex];
 
         if (subresource->msaaTexHandle != NULL) {
@@ -7362,11 +7362,11 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         }
     }
 
-    if (depth_stencil_attachment_info == NULL) {
+    if (depthStencilAttachmentInfo == NULL) {
         key.depthStencilAttachmentView = VK_NULL_HANDLE;
     } else {
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
-            (VulkanTextureContainer *)depth_stencil_attachment_info->texture,
+            (VulkanTextureContainer *)depthStencilAttachmentInfo->texture,
             0,
             0);
         key.depthStencilAttachmentView = subresource->depthStencilView;
@@ -7394,15 +7394,15 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
 
     // Create a new framebuffer
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+    for (i = 0; i < numColorAttachments; i += 1) {
+        VulkanTextureContainer *container = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layer_or_depth_plane,
+            colorAttachmentInfos[i].mip_level);
 
         Uint32 rtvIndex =
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layer_or_depth_plane : 0;
 
         imageViewAttachments[attachmentCount] =
             subresource->renderTargetViews[rtvIndex];
@@ -7417,9 +7417,9 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         }
     }
 
-    if (depth_stencil_attachment_info != NULL) {
+    if (depthStencilAttachmentInfo != NULL) {
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
-            (VulkanTextureContainer *)depth_stencil_attachment_info->texture,
+            (VulkanTextureContainer *)depthStencilAttachmentInfo->texture,
             0,
             0);
         imageViewAttachments[attachmentCount] = subresource->depthStencilView;
@@ -7430,7 +7430,7 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
     framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
     framebufferInfo.pNext = NULL;
     framebufferInfo.flags = 0;
-    framebufferInfo.renderPass = render_pass;
+    framebufferInfo.renderPass = renderPass;
     framebufferInfo.attachmentCount = attachmentCount;
     framebufferInfo.pAttachments = imageViewAttachments;
     framebufferInfo.width = key.width;
@@ -7466,10 +7466,10 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
 }
 
 static void VULKAN_INTERNAL_SetCurrentViewport(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     const SDL_GPUViewport *viewport)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
     vulkanCommandBuffer->currentViewport.x = viewport->x;
     vulkanCommandBuffer->currentViewport.width = viewport->w;
@@ -7483,10 +7483,10 @@ static void VULKAN_INTERNAL_SetCurrentViewport(
 }
 
 static void VULKAN_SetViewport(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUViewport *viewport)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentViewport(
@@ -7494,7 +7494,7 @@ static void VULKAN_SetViewport(
         viewport);
 
     renderer->vkCmdSetViewport(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         0,
         1,
         &vulkanCommandBuffer->currentViewport);
@@ -7511,10 +7511,10 @@ static void VULKAN_INTERNAL_SetCurrentScissor(
 }
 
 static void VULKAN_SetScissor(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_Rect *scissor)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentScissor(
@@ -7522,7 +7522,7 @@ static void VULKAN_SetScissor(
         scissor);
 
     renderer->vkCmdSetScissor(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         0,
         1,
         &vulkanCommandBuffer->currentScissor);
@@ -7530,28 +7530,28 @@ static void VULKAN_SetScissor(
 
 static void VULKAN_INTERNAL_SetCurrentBlendConstants(
     VulkanCommandBuffer *vulkanCommandBuffer,
-    SDL_FColor blend_constants)
+    SDL_FColor blendConstants)
 {
-    vulkanCommandBuffer->blend_constants[0] = blend_constants.r;
-    vulkanCommandBuffer->blend_constants[1] = blend_constants.g;
-    vulkanCommandBuffer->blend_constants[2] = blend_constants.b;
-    vulkanCommandBuffer->blend_constants[3] = blend_constants.a;
+    vulkanCommandBuffer->blendConstants[0] = blendConstants.r;
+    vulkanCommandBuffer->blendConstants[1] = blendConstants.g;
+    vulkanCommandBuffer->blendConstants[2] = blendConstants.b;
+    vulkanCommandBuffer->blendConstants[3] = blendConstants.a;
 }
 
 static void VULKAN_SetBlendConstants(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_FColor blend_constants)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_FColor blendConstants)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentBlendConstants(
         vulkanCommandBuffer,
-        blend_constants);
+        blendConstants);
 
     renderer->vkCmdSetBlendConstants(
-        vulkanCommandBuffer->command_buffer,
-        vulkanCommandBuffer->blend_constants);
+        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->blendConstants);
 }
 
 static void VULKAN_INTERNAL_SetCurrentStencilReference(
@@ -7562,10 +7562,10 @@ static void VULKAN_INTERNAL_SetCurrentStencilReference(
 }
 
 static void VULKAN_SetStencilReference(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     Uint8 reference)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentStencilReference(
@@ -7573,27 +7573,27 @@ static void VULKAN_SetStencilReference(
         reference);
 
     renderer->vkCmdSetStencilReference(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_STENCIL_FACE_FRONT_AND_BACK,
         reference);
 }
 
 static void VULKAN_BindVertexSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)texture_sampler_bindings[i].texture;
-        vulkanCommandBuffer->vertexSamplerTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
-        vulkanCommandBuffer->vertexSamplers[first_slot + i] = (VulkanSampler *)texture_sampler_bindings[i].sampler;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)textureSamplerBindings[i].texture;
+        vulkanCommandBuffer->vertexSamplerTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->vertexSamplers[firstSlot + i] = (VulkanSampler *)textureSamplerBindings[i].sampler;
 
         VULKAN_INTERNAL_TrackSampler(
             vulkanCommandBuffer,
-            (VulkanSampler *)texture_sampler_bindings[i].sampler);
+            (VulkanSampler *)textureSamplerBindings[i].sampler);
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7604,17 +7604,17 @@ static void VULKAN_BindVertexSamplers(
 }
 
 static void VULKAN_BindVertexStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
 
-        vulkanCommandBuffer->vertexStorageTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->vertexStorageTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7625,19 +7625,19 @@ static void VULKAN_BindVertexStorageTextures(
 }
 
 static void VULKAN_BindVertexStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
+    for (i = 0; i < numBindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
 
-        vulkanCommandBuffer->vertexStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->vertexStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_TrackBuffer(
             vulkanCommandBuffer,
@@ -7648,21 +7648,21 @@ static void VULKAN_BindVertexStorageBuffers(
 }
 
 static void VULKAN_BindFragmentSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)texture_sampler_bindings[i].texture;
-        vulkanCommandBuffer->fragmentSamplerTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
-        vulkanCommandBuffer->fragmentSamplers[first_slot + i] = (VulkanSampler *)texture_sampler_bindings[i].sampler;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)textureSamplerBindings[i].texture;
+        vulkanCommandBuffer->fragmentSamplerTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->fragmentSamplers[firstSlot + i] = (VulkanSampler *)textureSamplerBindings[i].sampler;
 
         VULKAN_INTERNAL_TrackSampler(
             vulkanCommandBuffer,
-            (VulkanSampler *)texture_sampler_bindings[i].sampler);
+            (VulkanSampler *)textureSamplerBindings[i].sampler);
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7673,17 +7673,17 @@ static void VULKAN_BindFragmentSamplers(
 }
 
 static void VULKAN_BindFragmentStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
 
-        vulkanCommandBuffer->fragmentStorageTextures[first_slot + i] =
+        vulkanCommandBuffer->fragmentStorageTextures[firstSlot + i] =
             textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TrackTexture(
@@ -7695,19 +7695,19 @@ static void VULKAN_BindFragmentStorageTextures(
 }
 
 static void VULKAN_BindFragmentStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
+    for (i = 0; i < numBindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
 
-        vulkanCommandBuffer->fragmentStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->fragmentStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_TrackBuffer(
             vulkanCommandBuffer,
@@ -7718,9 +7718,9 @@ static void VULKAN_BindFragmentStorageBuffers(
 }
 
 static VulkanUniformBuffer *VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
-    VulkanRenderer *renderer = command_buffer->renderer;
+    VulkanRenderer *renderer = commandBuffer->renderer;
     VulkanUniformBuffer *uniformBuffer;
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
@@ -7736,7 +7736,7 @@ static VulkanUniformBuffer *VULKAN_INTERNAL_AcquireUniformBufferFromPool(
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
-    VULKAN_INTERNAL_TrackUniformBuffer(command_buffer, uniformBuffer);
+    VULKAN_INTERNAL_TrackUniformBuffer(commandBuffer, uniformBuffer);
 
     return uniformBuffer;
 }
@@ -7760,37 +7760,37 @@ static void VULKAN_INTERNAL_ReturnUniformBufferToPool(
 }
 
 static void VULKAN_INTERNAL_PushUniformData(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanUniformBufferStage uniformBufferStage,
-    Uint32 slot_index,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     Uint32 blockSize =
         VULKAN_INTERNAL_NextHighestAlignment32(
             length,
-            command_buffer->renderer->minUBOAlignment);
+            commandBuffer->renderer->minUBOAlignment);
 
     VulkanUniformBuffer *uniformBuffer;
 
     if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-        if (command_buffer->vertexUniformBuffers[slot_index] == NULL) {
-            command_buffer->vertexUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->vertexUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->vertexUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->vertexUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->vertexUniformBuffers[slotIndex];
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-        if (command_buffer->fragmentUniformBuffers[slot_index] == NULL) {
-            command_buffer->fragmentUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->fragmentUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->fragmentUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->fragmentUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->fragmentUniformBuffers[slotIndex];
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-        if (command_buffer->computeUniformBuffers[slot_index] == NULL) {
-            command_buffer->computeUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->computeUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->computeUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->computeUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->computeUniformBuffers[slotIndex];
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -7798,20 +7798,20 @@ static void VULKAN_INTERNAL_PushUniformData(
 
     // If there is no more room, acquire a new uniform buffer
     if (uniformBuffer->writeOffset + blockSize + MAX_UBO_SECTION_SIZE >= uniformBuffer->bufferHandle->vulkanBuffer->size) {
-        uniformBuffer = VULKAN_INTERNAL_AcquireUniformBufferFromPool(command_buffer);
+        uniformBuffer = VULKAN_INTERNAL_AcquireUniformBufferFromPool(commandBuffer);
 
         uniformBuffer->drawOffset = 0;
         uniformBuffer->writeOffset = 0;
 
         if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-            command_buffer->vertexUniformBuffers[slot_index] = uniformBuffer;
-            command_buffer->needNewVertexUniformDescriptorSet = true;
+            commandBuffer->vertexUniformBuffers[slotIndex] = uniformBuffer;
+            commandBuffer->needNewVertexUniformDescriptorSet = true;
         } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-            command_buffer->fragmentUniformBuffers[slot_index] = uniformBuffer;
-            command_buffer->needNewFragmentUniformDescriptorSet = true;
+            commandBuffer->fragmentUniformBuffers[slotIndex] = uniformBuffer;
+            commandBuffer->needNewFragmentUniformDescriptorSet = true;
         } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-            command_buffer->computeUniformBuffers[slot_index] = uniformBuffer;
-            command_buffer->needNewComputeUniformDescriptorSet = true;
+            commandBuffer->computeUniformBuffers[slotIndex] = uniformBuffer;
+            commandBuffer->needNewComputeUniformDescriptorSet = true;
         } else {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
             return;
@@ -7833,11 +7833,11 @@ static void VULKAN_INTERNAL_PushUniformData(
     uniformBuffer->writeOffset += blockSize;
 
     if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-        command_buffer->needNewVertexUniformOffsets = true;
+        commandBuffer->needNewVertexUniformOffsets = true;
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-        command_buffer->needNewFragmentUniformOffsets = true;
+        commandBuffer->needNewFragmentUniformOffsets = true;
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-        command_buffer->needNewComputeUniformOffsets = true;
+        commandBuffer->needNewComputeUniformOffsets = true;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -7845,19 +7845,19 @@ static void VULKAN_INTERNAL_PushUniformData(
 }
 
 static void VULKAN_BeginRenderPass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
+    Uint32 numColorAttachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VkRenderPass render_pass;
+    VkRenderPass renderPass;
     VulkanFramebuffer *framebuffer;
 
     Uint32 w, h;
     VkClearValue *clearValues;
-    Uint32 clearCount = num_color_attachments;
+    Uint32 clearCount = numColorAttachments;
     Uint32 multisampleAttachmentCount = 0;
     Uint32 totalColorAttachmentCount = 0;
     Uint32 i;
@@ -7866,11 +7866,11 @@ static void VULKAN_BeginRenderPass(
     Uint32 framebufferWidth = UINT32_MAX;
     Uint32 framebufferHeight = UINT32_MAX;
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+    for (i = 0; i < numColorAttachments; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
 
-        w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width >> color_attachment_infos[i].mip_level;
-        h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height >> color_attachment_infos[i].mip_level;
+        w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width >> colorAttachmentInfos[i].mip_level;
+        h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height >> colorAttachmentInfos[i].mip_level;
 
         // The framebuffer cannot be larger than the smallest attachment.
 
@@ -7889,8 +7889,8 @@ static void VULKAN_BeginRenderPass(
         }
     }
 
-    if (depth_stencil_attachment_info != NULL) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depth_stencil_attachment_info->texture;
+    if (depthStencilAttachmentInfo != NULL) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depthStencilAttachmentInfo->texture;
 
         w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width;
         h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height;
@@ -7912,15 +7912,15 @@ static void VULKAN_BeginRenderPass(
         }
     }
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+    for (i = 0; i < numColorAttachments; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
-            textureContainer->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level,
-            color_attachment_infos[i].cycle,
+            textureContainer->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layer_or_depth_plane,
+            colorAttachmentInfos[i].mip_level,
+            colorAttachmentInfos[i].cycle,
             VULKAN_TEXTURE_USAGE_MODE_COLOR_ATTACHMENT);
 
         if (subresource->msaaTexHandle != NULL) {
@@ -7941,17 +7941,17 @@ static void VULKAN_BeginRenderPass(
         // TODO: do we need to track the msaa texture? or is it implicitly only used when the regular texture is used?
     }
 
-    vulkanCommandBuffer->colorAttachmentSubresourceCount = num_color_attachments;
+    vulkanCommandBuffer->colorAttachmentSubresourceCount = numColorAttachments;
 
-    if (depth_stencil_attachment_info != NULL) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depth_stencil_attachment_info->texture;
+    if (depthStencilAttachmentInfo != NULL) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depthStencilAttachmentInfo->texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
             0,
             0,
-            depth_stencil_attachment_info->cycle,
+            depthStencilAttachmentInfo->cycle,
             VULKAN_TEXTURE_USAGE_MODE_DEPTH_STENCIL_ATTACHMENT);
 
         clearCount += 1;
@@ -7963,19 +7963,19 @@ static void VULKAN_BeginRenderPass(
 
     // Fetch required render objects
 
-    render_pass = VULKAN_INTERNAL_FetchRenderPass(
+    renderPass = VULKAN_INTERNAL_FetchRenderPass(
         renderer,
         vulkanCommandBuffer,
-        color_attachment_infos,
-        num_color_attachments,
-        depth_stencil_attachment_info);
+        colorAttachmentInfos,
+        numColorAttachments,
+        depthStencilAttachmentInfo);
 
     framebuffer = VULKAN_INTERNAL_FetchFramebuffer(
         renderer,
-        render_pass,
-        color_attachment_infos,
-        num_color_attachments,
-        depth_stencil_attachment_info,
+        renderPass,
+        colorAttachmentInfos,
+        numColorAttachments,
+        depthStencilAttachmentInfo,
         framebufferWidth,
         framebufferHeight);
 
@@ -7985,40 +7985,40 @@ static void VULKAN_BeginRenderPass(
 
     clearValues = SDL_stack_alloc(VkClearValue, clearCount);
 
-    totalColorAttachmentCount = num_color_attachments + multisampleAttachmentCount;
+    totalColorAttachmentCount = numColorAttachments + multisampleAttachmentCount;
 
     for (i = 0; i < totalColorAttachmentCount; i += 1) {
-        clearValues[i].color.float32[0] = color_attachment_infos[i].clear_color.r;
-        clearValues[i].color.float32[1] = color_attachment_infos[i].clear_color.g;
-        clearValues[i].color.float32[2] = color_attachment_infos[i].clear_color.b;
-        clearValues[i].color.float32[3] = color_attachment_infos[i].clear_color.a;
+        clearValues[i].color.float32[0] = colorAttachmentInfos[i].clear_color.r;
+        clearValues[i].color.float32[1] = colorAttachmentInfos[i].clear_color.g;
+        clearValues[i].color.float32[2] = colorAttachmentInfos[i].clear_color.b;
+        clearValues[i].color.float32[3] = colorAttachmentInfos[i].clear_color.a;
 
-        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+        VulkanTextureContainer *container = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layer_or_depth_plane,
+            colorAttachmentInfos[i].mip_level);
 
-        if (subresource->parent->sample_count > VK_SAMPLE_COUNT_1_BIT) {
-            clearValues[i + 1].color.float32[0] = color_attachment_infos[i].clear_color.r;
-            clearValues[i + 1].color.float32[1] = color_attachment_infos[i].clear_color.g;
-            clearValues[i + 1].color.float32[2] = color_attachment_infos[i].clear_color.b;
-            clearValues[i + 1].color.float32[3] = color_attachment_infos[i].clear_color.a;
+        if (subresource->parent->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
+            clearValues[i + 1].color.float32[0] = colorAttachmentInfos[i].clear_color.r;
+            clearValues[i + 1].color.float32[1] = colorAttachmentInfos[i].clear_color.g;
+            clearValues[i + 1].color.float32[2] = colorAttachmentInfos[i].clear_color.b;
+            clearValues[i + 1].color.float32[3] = colorAttachmentInfos[i].clear_color.a;
             i += 1;
         }
     }
 
-    if (depth_stencil_attachment_info != NULL) {
+    if (depthStencilAttachmentInfo != NULL) {
         clearValues[totalColorAttachmentCount].depthStencil.depth =
-            depth_stencil_attachment_info->clear_value.depth;
+            depthStencilAttachmentInfo->clear_value.depth;
         clearValues[totalColorAttachmentCount].depthStencil.stencil =
-            depth_stencil_attachment_info->clear_value.stencil;
+            depthStencilAttachmentInfo->clear_value.stencil;
     }
 
     VkRenderPassBeginInfo renderPassBeginInfo;
     renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
     renderPassBeginInfo.pNext = NULL;
-    renderPassBeginInfo.renderPass = render_pass;
+    renderPassBeginInfo.renderPass = renderPass;
     renderPassBeginInfo.framebuffer = framebuffer->framebuffer;
     renderPassBeginInfo.pClearValues = clearValues;
     renderPassBeginInfo.clearValueCount = clearCount;
@@ -8028,7 +8028,7 @@ static void VULKAN_BeginRenderPass(
     renderPassBeginInfo.renderArea.offset.y = 0;
 
     renderer->vkCmdBeginRenderPass(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         &renderPassBeginInfo,
         VK_SUBPASS_CONTENTS_INLINE);
 
@@ -8066,15 +8066,15 @@ static void VULKAN_BeginRenderPass(
 }
 
 static void VULKAN_BindGraphicsPipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanGraphicsPipeline *pipeline = (VulkanGraphicsPipeline *)graphics_pipeline;
+    VulkanGraphicsPipeline *pipeline = (VulkanGraphicsPipeline *)graphicsPipeline;
 
     renderer->vkCmdBindPipeline(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_PIPELINE_BIND_POINT_GRAPHICS,
         pipeline->pipeline);
 
@@ -8083,23 +8083,23 @@ static void VULKAN_BindGraphicsPipeline(
     VULKAN_INTERNAL_TrackGraphicsPipeline(vulkanCommandBuffer, pipeline);
 
     renderer->vkCmdSetViewport(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         0,
         1,
         &vulkanCommandBuffer->currentViewport);
 
     renderer->vkCmdSetScissor(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         0,
         1,
         &vulkanCommandBuffer->currentScissor);
 
     renderer->vkCmdSetBlendConstants(
-        vulkanCommandBuffer->command_buffer,
-        vulkanCommandBuffer->blend_constants);
+        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->blendConstants);
 
     renderer->vkCmdSetStencilReference(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_STENCIL_FACE_FRONT_AND_BACK,
         vulkanCommandBuffer->stencilRef);
 
@@ -8128,19 +8128,19 @@ static void VULKAN_BindGraphicsPipeline(
 }
 
 static void VULKAN_BindVertexBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_binding,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstBinding,
     const SDL_GPUBufferBinding *bindings,
-    Uint32 num_bindings)
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *currentVulkanBuffer;
-    VkBuffer *buffers = SDL_stack_alloc(VkBuffer, num_bindings);
-    VkDeviceSize *offsets = SDL_stack_alloc(VkDeviceSize, num_bindings);
+    VkBuffer *buffers = SDL_stack_alloc(VkBuffer, numBindings);
+    VkDeviceSize *offsets = SDL_stack_alloc(VkDeviceSize, numBindings);
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
+    for (i = 0; i < numBindings; i += 1) {
         currentVulkanBuffer = ((VulkanBufferContainer *)bindings[i].buffer)->activeBufferHandle->vulkanBuffer;
         buffers[i] = currentVulkanBuffer->buffer;
         offsets[i] = (VkDeviceSize)bindings[i].offset;
@@ -8148,9 +8148,9 @@ static void VULKAN_BindVertexBuffers(
     }
 
     renderer->vkCmdBindVertexBuffers(
-        vulkanCommandBuffer->command_buffer,
-        first_binding,
-        num_bindings,
+        vulkanCommandBuffer->commandBuffer,
+        firstBinding,
+        numBindings,
         buffers,
         offsets);
 
@@ -8159,64 +8159,64 @@ static void VULKAN_BindVertexBuffers(
 }
 
 static void VULKAN_BindIndexBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize index_element_size)
+    SDL_GPUIndexElementSize indexElementSize)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)pBinding->buffer)->activeBufferHandle->vulkanBuffer;
 
     VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, vulkanBuffer);
 
     renderer->vkCmdBindIndexBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         vulkanBuffer->buffer,
         (VkDeviceSize)pBinding->offset,
-        SDLToVK_IndexType[index_element_size]);
+        SDLToVK_IndexType[indexElementSize]);
 }
 
 static void VULKAN_PushVertexUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_VERTEX,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void VULKAN_PushFragmentUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void VULKAN_EndRenderPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     Uint32 i;
 
     renderer->vkCmdEndRenderPass(
-        vulkanCommandBuffer->command_buffer);
+        vulkanCommandBuffer->commandBuffer);
 
     for (i = 0; i < vulkanCommandBuffer->colorAttachmentSubresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
@@ -8259,23 +8259,23 @@ static void VULKAN_EndRenderPass(
 }
 
 static void VULKAN_BeginComputePass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
-    Uint32 num_storage_texture_bindings,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
-    Uint32 num_storage_buffer_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
+    Uint32 numStorageTextureBindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
+    Uint32 numStorageBufferBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer;
     VulkanBuffer *buffer;
     Uint32 i;
 
-    vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount = num_storage_texture_bindings;
+    vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount = numStorageTextureBindings;
 
-    for (i = 0; i < num_storage_texture_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_texture_bindings[i].texture;
-        if (!(textureContainer->activeTextureHandle->vulkanTexture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
+    for (i = 0; i < numStorageTextureBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextureBindings[i].texture;
+        if (!(textureContainer->activeTextureHandle->vulkanTexture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
         }
 
@@ -8283,9 +8283,9 @@ static void VULKAN_BeginComputePass(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
-            storage_texture_bindings[i].layer,
-            storage_texture_bindings[i].mip_level,
-            storage_texture_bindings[i].cycle,
+            storageTextureBindings[i].layer,
+            storageTextureBindings[i].mip_level,
+            storageTextureBindings[i].cycle,
             VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE);
 
         vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresources[i] = subresource;
@@ -8295,13 +8295,13 @@ static void VULKAN_BeginComputePass(
             subresource->parent);
     }
 
-    for (i = 0; i < num_storage_buffer_bindings; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storage_buffer_bindings[i].buffer;
+    for (i = 0; i < numStorageBufferBindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storageBufferBindings[i].buffer;
         buffer = VULKAN_INTERNAL_PrepareBufferForWrite(
             renderer,
             vulkanCommandBuffer,
             bufferContainer,
-            storage_buffer_bindings[i].cycle,
+            storageBufferBindings[i].cycle,
             VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ);
 
         vulkanCommandBuffer->writeOnlyComputeStorageBuffers[i] = buffer;
@@ -8313,15 +8313,15 @@ static void VULKAN_BeginComputePass(
 }
 
 static void VULKAN_BindComputePipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUComputePipeline *computePipeline)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)compute_pipeline;
+    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)computePipeline;
 
     renderer->vkCmdBindPipeline(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_PIPELINE_BIND_POINT_COMPUTE,
         vulkanComputePipeline->pipeline);
 
@@ -8330,7 +8330,7 @@ static void VULKAN_BindComputePipeline(
     VULKAN_INTERNAL_TrackComputePipeline(vulkanCommandBuffer, vulkanComputePipeline);
 
     // Acquire uniform buffers if necessary
-    for (Uint32 i = 0; i < vulkanComputePipeline->resourceLayout.num_uniform_buffers; i += 1) {
+    for (Uint32 i = 0; i < vulkanComputePipeline->resourceLayout.numUniformBuffers; i += 1) {
         if (vulkanCommandBuffer->computeUniformBuffers[i] == NULL) {
             vulkanCommandBuffer->computeUniformBuffers[i] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
                 vulkanCommandBuffer);
@@ -8345,26 +8345,26 @@ static void VULKAN_BindComputePipeline(
 }
 
 static void VULKAN_BindComputeStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        if (vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i] != NULL) {
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        if (vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i] != NULL) {
             VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
                 renderer,
                 vulkanCommandBuffer,
                 VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ,
-                vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i]);
+                vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i]);
         }
 
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
 
-        vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i] =
+        vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i] =
             textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
@@ -8382,28 +8382,28 @@ static void VULKAN_BindComputeStorageTextures(
 }
 
 static void VULKAN_BindComputeStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        if (vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i] != NULL) {
+    for (i = 0; i < numBindings; i += 1) {
+        if (vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i] != NULL) {
             VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
                 renderer,
                 vulkanCommandBuffer,
                 VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ,
-                vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i]);
+                vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i]);
         }
 
-        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
+        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
 
-        vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
             renderer,
@@ -8420,24 +8420,24 @@ static void VULKAN_BindComputeStorageBuffers(
 }
 
 static void VULKAN_PushComputeUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void VULKAN_INTERNAL_BindComputeDescriptorSets(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     VulkanComputePipelineResourceLayout *resourceLayout;
     VkWriteDescriptorSet *writeDescriptorSets;
@@ -8450,22 +8450,22 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
     Uint32 imageInfoCount = 0;
     Uint32 i;
 
-    resourceLayout = &command_buffer->currentComputePipeline->resourceLayout;
+    resourceLayout = &commandBuffer->currentComputePipeline->resourceLayout;
 
-    if (command_buffer->needNewComputeReadOnlyDescriptorSet) {
+    if (commandBuffer->needNewComputeReadOnlyDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[0];
 
-        command_buffer->computeReadOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->computeReadOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->num_readonly_storage_textures +
-                resourceLayout->num_readonly_storage_buffers);
+            resourceLayout->numReadonlyStorageTextures +
+                resourceLayout->numReadonlyStorageBuffers);
 
-        for (i = 0; i < resourceLayout->num_readonly_storage_textures; i += 1) {
+        for (i = 0; i < resourceLayout->numReadonlyStorageTextures; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
@@ -8473,12 +8473,12 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeReadOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeReadOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = command_buffer->readOnlyComputeStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = commandBuffer->readOnlyComputeStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -8486,20 +8486,20 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             imageInfoCount += 1;
         }
 
-        for (i = 0; i < resourceLayout->num_readonly_storage_buffers; i += 1) {
-            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->num_readonly_storage_textures + i];
+        for (i = 0; i < resourceLayout->numReadonlyStorageBuffers; i += 1) {
+            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->numReadonlyStorageTextures + i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
             currentWriteDescriptorSet->descriptorCount = 1;
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
-            currentWriteDescriptorSet->dstBinding = resourceLayout->num_readonly_storage_textures + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeReadOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstBinding = resourceLayout->numReadonlyStorageTextures + i;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeReadOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->readOnlyComputeStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->readOnlyComputeStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -8510,18 +8510,18 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->num_readonly_storage_textures + resourceLayout->num_readonly_storage_buffers,
+            resourceLayout->numReadonlyStorageTextures + resourceLayout->numReadonlyStorageBuffers,
             writeDescriptorSets,
             0,
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             0,
             1,
-            &command_buffer->computeReadOnlyDescriptorSet,
+            &commandBuffer->computeReadOnlyDescriptorSet,
             0,
             NULL);
 
@@ -8529,23 +8529,23 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewComputeReadOnlyDescriptorSet = false;
+        commandBuffer->needNewComputeReadOnlyDescriptorSet = false;
     }
 
-    if (command_buffer->needNewComputeWriteOnlyDescriptorSet) {
+    if (commandBuffer->needNewComputeWriteOnlyDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[1];
 
-        command_buffer->computeWriteOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->computeWriteOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->num_writeonly_storage_textures +
-                resourceLayout->num_writeonly_storage_buffers);
+            resourceLayout->numWriteonlyStorageTextures +
+                resourceLayout->numWriteonlyStorageBuffers);
 
-        for (i = 0; i < resourceLayout->num_writeonly_storage_textures; i += 1) {
+        for (i = 0; i < resourceLayout->numWriteonlyStorageTextures; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -8554,12 +8554,12 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeWriteOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeWriteOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = command_buffer->writeOnlyComputeStorageTextureSubresources[i]->computeWriteView;
+            imageInfos[imageInfoCount].imageView = commandBuffer->writeOnlyComputeStorageTextureSubresources[i]->computeWriteView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -8567,20 +8567,20 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             imageInfoCount += 1;
         }
 
-        for (i = 0; i < resourceLayout->num_writeonly_storage_buffers; i += 1) {
-            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->num_writeonly_storage_textures + i];
+        for (i = 0; i < resourceLayout->numWriteonlyStorageBuffers; i += 1) {
+            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->numWriteonlyStorageTextures + i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
             currentWriteDescriptorSet->descriptorCount = 1;
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
-            currentWriteDescriptorSet->dstBinding = resourceLayout->num_writeonly_storage_textures + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeWriteOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstBinding = resourceLayout->numWriteonlyStorageTextures + i;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeWriteOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->writeOnlyComputeStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->writeOnlyComputeStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -8591,18 +8591,18 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->num_writeonly_storage_textures + resourceLayout->num_writeonly_storage_buffers,
+            resourceLayout->numWriteonlyStorageTextures + resourceLayout->numWriteonlyStorageBuffers,
             writeDescriptorSets,
             0,
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             1,
             1,
-            &command_buffer->computeWriteOnlyDescriptorSet,
+            &commandBuffer->computeWriteOnlyDescriptorSet,
             0,
             NULL);
 
@@ -8610,22 +8610,22 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewComputeWriteOnlyDescriptorSet = false;
+        commandBuffer->needNewComputeWriteOnlyDescriptorSet = false;
     }
 
-    if (command_buffer->needNewComputeUniformDescriptorSet) {
+    if (commandBuffer->needNewComputeUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[2];
 
-        command_buffer->computeUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->computeUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->num_uniform_buffers);
+            resourceLayout->numUniformBuffers);
 
-        for (i = 0; i < resourceLayout->num_uniform_buffers; i += 1) {
+        for (i = 0; i < resourceLayout->numUniformBuffers; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -8634,11 +8634,11 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->computeUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->computeUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -8649,7 +8649,7 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->num_uniform_buffers,
+            resourceLayout->numUniformBuffers,
             writeDescriptorSets,
             0,
             NULL);
@@ -8658,60 +8658,60 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewComputeUniformDescriptorSet = false;
-        command_buffer->needNewComputeUniformOffsets = true;
+        commandBuffer->needNewComputeUniformDescriptorSet = false;
+        commandBuffer->needNewComputeUniformOffsets = true;
     }
 
-    if (command_buffer->needNewComputeUniformOffsets) {
-        for (i = 0; i < resourceLayout->num_uniform_buffers; i += 1) {
-            dynamicOffsets[i] = command_buffer->computeUniformBuffers[i]->drawOffset;
+    if (commandBuffer->needNewComputeUniformOffsets) {
+        for (i = 0; i < resourceLayout->numUniformBuffers; i += 1) {
+            dynamicOffsets[i] = commandBuffer->computeUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             2,
             1,
-            &command_buffer->computeUniformDescriptorSet,
-            resourceLayout->num_uniform_buffers,
+            &commandBuffer->computeUniformDescriptorSet,
+            resourceLayout->numUniformBuffers,
             dynamicOffsets);
 
-        command_buffer->needNewComputeUniformOffsets = false;
+        commandBuffer->needNewComputeUniformOffsets = false;
     }
 }
 
 static void VULKAN_DispatchCompute(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 groupcount_x,
-    Uint32 groupcount_y,
-    Uint32 groupcount_z)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 groupcountX,
+    Uint32 groupcountY,
+    Uint32 groupcountZ)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindComputeDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDispatch(
-        vulkanCommandBuffer->command_buffer,
-        groupcount_x,
-        groupcount_y,
-        groupcount_z);
+        vulkanCommandBuffer->commandBuffer,
+        groupcountX,
+        groupcountY,
+        groupcountZ);
 }
 
 static void VULKAN_DispatchComputeIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
 
     VULKAN_INTERNAL_BindComputeDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDispatchIndirect(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         vulkanBuffer->buffer,
         offset);
 
@@ -8719,9 +8719,9 @@ static void VULKAN_DispatchComputeIndirect(
 }
 
 static void VULKAN_EndComputePass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     Uint32 i;
 
     for (i = 0; i < vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount; i += 1) {
@@ -8779,11 +8779,11 @@ static void VULKAN_EndComputePass(
 
 static void *VULKAN_MapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer,
+    SDL_GPUTransferBuffer *transferBuffer,
     bool cycle)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transfer_buffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
 
     if (
         cycle &&
@@ -8802,27 +8802,27 @@ static void *VULKAN_MapTransferBuffer(
 
 static void VULKAN_UnmapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     // no-op because transfer buffers are persistently mapped
     (void)driverData;
-    (void)transfer_buffer;
+    (void)transferBuffer;
 }
 
 static void VULKAN_BeginCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     // no-op
-    (void)command_buffer;
+    (void)commandBuffer;
 }
 
 static void VULKAN_UploadToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transfer_buffer;
     VulkanTextureContainer *vulkanTextureContainer = (VulkanTextureContainer *)destination->texture;
@@ -8855,7 +8855,7 @@ static void VULKAN_UploadToTexture(
     imageCopy.bufferImageHeight = source->rows_per_layer;
 
     renderer->vkCmdCopyBufferToImage(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         vulkanTextureSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -8873,12 +8873,12 @@ static void VULKAN_UploadToTexture(
 }
 
 static void VULKAN_UploadToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transfer_buffer;
     VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)destination->buffer;
@@ -8898,7 +8898,7 @@ static void VULKAN_UploadToBuffer(
     bufferCopy.size = destination->size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         vulkanBuffer->buffer,
         1,
@@ -8917,11 +8917,11 @@ static void VULKAN_UploadToBuffer(
 // Readback
 
 static void VULKAN_DownloadFromTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)source->texture;
     VulkanTextureSubresource *vulkanTextureSubresource;
@@ -8955,7 +8955,7 @@ static void VULKAN_DownloadFromTexture(
     imageCopy.bufferImageHeight = destination->rows_per_layer;
 
     renderer->vkCmdCopyImageToBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         vulkanTextureSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
@@ -8973,11 +8973,11 @@ static void VULKAN_DownloadFromTexture(
 }
 
 static void VULKAN_DownloadFromBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)source->buffer;
     VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination->transfer_buffer;
@@ -8996,7 +8996,7 @@ static void VULKAN_DownloadFromBuffer(
     bufferCopy.size = source->size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         bufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         1,
@@ -9013,7 +9013,7 @@ static void VULKAN_DownloadFromBuffer(
 }
 
 static void VULKAN_CopyTextureToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -9021,7 +9021,7 @@ static void VULKAN_CopyTextureToTexture(
     Uint32 d,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanTextureSubresource *srcSubresource;
     VulkanTextureSubresource *dstSubresource;
@@ -9066,7 +9066,7 @@ static void VULKAN_CopyTextureToTexture(
     imageCopy.extent.depth = d;
 
     renderer->vkCmdCopyImage(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         srcSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         dstSubresource->parent->image,
@@ -9091,13 +9091,13 @@ static void VULKAN_CopyTextureToTexture(
 }
 
 static void VULKAN_CopyBufferToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBufferContainer *srcContainer = (VulkanBufferContainer *)source->buffer;
     VulkanBufferContainer *dstContainer = (VulkanBufferContainer *)destination->buffer;
@@ -9121,7 +9121,7 @@ static void VULKAN_CopyBufferToBuffer(
     bufferCopy.size = size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         srcContainer->activeBufferHandle->vulkanBuffer->buffer,
         dstBuffer->buffer,
         1,
@@ -9144,10 +9144,10 @@ static void VULKAN_CopyBufferToBuffer(
 }
 
 static void VULKAN_GenerateMipmaps(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUTexture *texture)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanTexture *vulkanTexture = ((VulkanTextureContainer *)texture)->activeTextureHandle->vulkanTexture;
     VulkanTextureSubresource *srcTextureSubresource;
@@ -9156,18 +9156,18 @@ static void VULKAN_GenerateMipmaps(
 
     // Blit each slice sequentially. Barriers, barriers everywhere!
     for (Uint32 layerOrDepthIndex = 0; layerOrDepthIndex < vulkanTexture->layerCount; layerOrDepthIndex += 1)
-        for (Uint32 level = 1; level < vulkanTexture->num_levels; level += 1) {
+        for (Uint32 level = 1; level < vulkanTexture->numLevels; level += 1) {
             Uint32 layer = vulkanTexture->type == SDL_GPU_TEXTURETYPE_3D ? 0 : layerOrDepthIndex;
             Uint32 depth = vulkanTexture->type == SDL_GPU_TEXTURETYPE_3D ? layerOrDepthIndex : 0;
 
             Uint32 srcSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level - 1,
                 layer,
-                vulkanTexture->num_levels);
+                vulkanTexture->numLevels);
             Uint32 dstSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level,
                 layer,
-                vulkanTexture->num_levels);
+                vulkanTexture->numLevels);
 
             srcTextureSubresource = &vulkanTexture->subresources[srcSubresourceIndex];
             dstTextureSubresource = &vulkanTexture->subresources[dstSubresourceIndex];
@@ -9211,7 +9211,7 @@ static void VULKAN_GenerateMipmaps(
             blit.dstSubresource.mipLevel = level;
 
             renderer->vkCmdBlitImage(
-                vulkanCommandBuffer->command_buffer,
+                vulkanCommandBuffer->commandBuffer,
                 vulkanTexture->image,
                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                 vulkanTexture->image,
@@ -9238,21 +9238,21 @@ static void VULKAN_GenerateMipmaps(
 }
 
 static void VULKAN_EndCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     // no-op
-    (void)command_buffer;
+    (void)commandBuffer;
 }
 
 static void VULKAN_Blit(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flip_mode,
+    SDL_FlipMode flipMode,
     SDL_GPUFilter filter,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     TextureCommonHeader *srcHeader = (TextureCommonHeader *)source->texture;
     TextureCommonHeader *dstHeader = (TextureCommonHeader *)destination->texture;
@@ -9294,14 +9294,14 @@ static void VULKAN_Blit(
     region.srcOffsets[1].y = source->y + source->h;
     region.srcOffsets[1].z = srcDepth + 1;
 
-    if (flip_mode & SDL_FLIP_HORIZONTAL) {
+    if (flipMode & SDL_FLIP_HORIZONTAL) {
         // flip the x positions
         swap = region.srcOffsets[0].x;
         region.srcOffsets[0].x = region.srcOffsets[1].x;
         region.srcOffsets[1].x = swap;
     }
 
-    if (flip_mode & SDL_FLIP_VERTICAL) {
+    if (flipMode & SDL_FLIP_VERTICAL) {
         // flip the y positions
         swap = region.srcOffsets[0].y;
         region.srcOffsets[0].y = region.srcOffsets[1].y;
@@ -9320,7 +9320,7 @@ static void VULKAN_Blit(
     region.dstOffsets[1].z = dstDepth + 1;
 
     renderer->vkCmdBlitImage(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         srcSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         dstSubresource->parent->image,
@@ -9354,7 +9354,7 @@ static void VULKAN_INTERNAL_AllocateCommandBuffers(
     VkResult vulkanResult;
     Uint32 i;
     VkCommandBuffer *commandBuffers = SDL_stack_alloc(VkCommandBuffer, allocateCount);
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
 
     vulkanCommandPool->inactiveCommandBufferCapacity += allocateCount;
 
@@ -9381,100 +9381,100 @@ static void VULKAN_INTERNAL_AllocateCommandBuffers(
     }
 
     for (i = 0; i < allocateCount; i += 1) {
-        command_buffer = SDL_malloc(sizeof(VulkanCommandBuffer));
-        command_buffer->renderer = renderer;
-        command_buffer->commandPool = vulkanCommandPool;
-        command_buffer->command_buffer = commandBuffers[i];
+        commandBuffer = SDL_malloc(sizeof(VulkanCommandBuffer));
+        commandBuffer->renderer = renderer;
+        commandBuffer->commandPool = vulkanCommandPool;
+        commandBuffer->commandBuffer = commandBuffers[i];
 
-        command_buffer->inFlightFence = VK_NULL_HANDLE;
+        commandBuffer->inFlightFence = VK_NULL_HANDLE;
 
         // Presentation tracking
 
-        command_buffer->presentDataCapacity = 1;
-        command_buffer->presentDataCount = 0;
-        command_buffer->presentDatas = SDL_malloc(
-            command_buffer->presentDataCapacity * sizeof(VulkanPresentData));
+        commandBuffer->presentDataCapacity = 1;
+        commandBuffer->presentDataCount = 0;
+        commandBuffer->presentDatas = SDL_malloc(
+            commandBuffer->presentDataCapacity * sizeof(VulkanPresentData));
 
-        command_buffer->waitSemaphoreCapacity = 1;
-        command_buffer->waitSemaphoreCount = 0;
-        command_buffer->waitSemaphores = SDL_malloc(
-            command_buffer->waitSemaphoreCapacity * sizeof(VkSemaphore));
+        commandBuffer->waitSemaphoreCapacity = 1;
+        commandBuffer->waitSemaphoreCount = 0;
+        commandBuffer->waitSemaphores = SDL_malloc(
+            commandBuffer->waitSemaphoreCapacity * sizeof(VkSemaphore));
 
-        command_buffer->signalSemaphoreCapacity = 1;
-        command_buffer->signalSemaphoreCount = 0;
-        command_buffer->signalSemaphores = SDL_malloc(
-            command_buffer->signalSemaphoreCapacity * sizeof(VkSemaphore));
+        commandBuffer->signalSemaphoreCapacity = 1;
+        commandBuffer->signalSemaphoreCount = 0;
+        commandBuffer->signalSemaphores = SDL_malloc(
+            commandBuffer->signalSemaphoreCapacity * sizeof(VkSemaphore));
 
         // Descriptor set tracking
 
-        command_buffer->boundDescriptorSetDataCapacity = 16;
-        command_buffer->boundDescriptorSetDataCount = 0;
-        command_buffer->boundDescriptorSetDatas = SDL_malloc(
-            command_buffer->boundDescriptorSetDataCapacity * sizeof(DescriptorSetData));
+        commandBuffer->boundDescriptorSetDataCapacity = 16;
+        commandBuffer->boundDescriptorSetDataCount = 0;
+        commandBuffer->boundDescriptorSetDatas = SDL_malloc(
+            commandBuffer->boundDescriptorSetDataCapacity * sizeof(DescriptorSetData));
 
         // Resource bind tracking
 
-        command_buffer->needNewVertexResourceDescriptorSet = true;
-        command_buffer->needNewVertexUniformDescriptorSet = true;
-        command_buffer->needNewVertexUniformOffsets = true;
-        command_buffer->needNewFragmentResourceDescriptorSet = true;
-        command_buffer->needNewFragmentUniformDescriptorSet = true;
-        command_buffer->needNewFragmentUniformOffsets = true;
+        commandBuffer->needNewVertexResourceDescriptorSet = true;
+        commandBuffer->needNewVertexUniformDescriptorSet = true;
+        commandBuffer->needNewVertexUniformOffsets = true;
+        commandBuffer->needNewFragmentResourceDescriptorSet = true;
+        commandBuffer->needNewFragmentUniformDescriptorSet = true;
+        commandBuffer->needNewFragmentUniformOffsets = true;
 
-        command_buffer->needNewComputeWriteOnlyDescriptorSet = true;
-        command_buffer->needNewComputeReadOnlyDescriptorSet = true;
-        command_buffer->needNewComputeUniformDescriptorSet = true;
-        command_buffer->needNewComputeUniformOffsets = true;
+        commandBuffer->needNewComputeWriteOnlyDescriptorSet = true;
+        commandBuffer->needNewComputeReadOnlyDescriptorSet = true;
+        commandBuffer->needNewComputeUniformDescriptorSet = true;
+        commandBuffer->needNewComputeUniformOffsets = true;
 
-        command_buffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
 
-        command_buffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
 
         // Resource tracking
 
-        command_buffer->usedBufferCapacity = 4;
-        command_buffer->usedBufferCount = 0;
-        command_buffer->usedBuffers = SDL_malloc(
-            command_buffer->usedBufferCapacity * sizeof(VulkanBuffer *));
+        commandBuffer->usedBufferCapacity = 4;
+        commandBuffer->usedBufferCount = 0;
+        commandBuffer->usedBuffers = SDL_malloc(
+            commandBuffer->usedBufferCapacity * sizeof(VulkanBuffer *));
 
-        command_buffer->usedTextureCapacity = 4;
-        command_buffer->usedTextureCount = 0;
-        command_buffer->usedTextures = SDL_malloc(
-            command_buffer->usedTextureCapacity * sizeof(VulkanTexture *));
+        commandBuffer->usedTextureCapacity = 4;
+        commandBuffer->usedTextureCount = 0;
+        commandBuffer->usedTextures = SDL_malloc(
+            commandBuffer->usedTextureCapacity * sizeof(VulkanTexture *));
 
-        command_buffer->usedSamplerCapacity = 4;
-        command_buffer->usedSamplerCount = 0;
-        command_buffer->usedSamplers = SDL_malloc(
-            command_buffer->usedSamplerCapacity * sizeof(VulkanSampler *));
+        commandBuffer->usedSamplerCapacity = 4;
+        commandBuffer->usedSamplerCount = 0;
+        commandBuffer->usedSamplers = SDL_malloc(
+            commandBuffer->usedSamplerCapacity * sizeof(VulkanSampler *));
 
-        command_buffer->usedGraphicsPipelineCapacity = 4;
-        command_buffer->usedGraphicsPipelineCount = 0;
-        command_buffer->usedGraphicsPipelines = SDL_malloc(
-            command_buffer->usedGraphicsPipelineCapacity * sizeof(VulkanGraphicsPipeline *));
+        commandBuffer->usedGraphicsPipelineCapacity = 4;
+        commandBuffer->usedGraphicsPipelineCount = 0;
+        commandBuffer->usedGraphicsPipelines = SDL_malloc(
+            commandBuffer->usedGraphicsPipelineCapacity * sizeof(VulkanGraphicsPipeline *));
 
-        command_buffer->usedComputePipelineCapacity = 4;
-        command_buffer->usedComputePipelineCount = 0;
-        command_buffer->usedComputePipelines = SDL_malloc(
-            command_buffer->usedComputePipelineCapacity * sizeof(VulkanComputePipeline *));
+        commandBuffer->usedComputePipelineCapacity = 4;
+        commandBuffer->usedComputePipelineCount = 0;
+        commandBuffer->usedComputePipelines = SDL_malloc(
+            commandBuffer->usedComputePipelineCapacity * sizeof(VulkanComputePipeline *));
 
-        command_buffer->usedFramebufferCapacity = 4;
-        command_buffer->usedFramebufferCount = 0;
-        command_buffer->usedFramebuffers = SDL_malloc(
-            command_buffer->usedFramebufferCapacity * sizeof(VulkanFramebuffer *));
+        commandBuffer->usedFramebufferCapacity = 4;
+        commandBuffer->usedFramebufferCount = 0;
+        commandBuffer->usedFramebuffers = SDL_malloc(
+            commandBuffer->usedFramebufferCapacity * sizeof(VulkanFramebuffer *));
 
-        command_buffer->usedUniformBufferCapacity = 4;
-        command_buffer->usedUniformBufferCount = 0;
-        command_buffer->usedUniformBuffers = SDL_malloc(
-            command_buffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
+        commandBuffer->usedUniformBufferCapacity = 4;
+        commandBuffer->usedUniformBufferCount = 0;
+        commandBuffer->usedUniformBuffers = SDL_malloc(
+            commandBuffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
 
         // Pool it!
 
-        vulkanCommandPool->inactiveCommandBuffers[vulkanCommandPool->inactiveCommandBufferCount] = command_buffer;
+        vulkanCommandPool->inactiveCommandBuffers[vulkanCommandPool->inactiveCommandBufferCount] = commandBuffer;
         vulkanCommandPool->inactiveCommandBufferCount += 1;
     }
 
@@ -9547,7 +9547,7 @@ static VulkanCommandBuffer *VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(
 {
     VulkanCommandPool *commandPool =
         VULKAN_INTERNAL_FetchCommandPool(renderer, threadID);
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
 
     if (commandPool == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to fetch command pool!");
@@ -9561,10 +9561,10 @@ static VulkanCommandBuffer *VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(
             commandPool->inactiveCommandBufferCapacity);
     }
 
-    command_buffer = commandPool->inactiveCommandBuffers[commandPool->inactiveCommandBufferCount - 1];
+    commandBuffer = commandPool->inactiveCommandBuffers[commandPool->inactiveCommandBufferCount - 1];
     commandPool->inactiveCommandBufferCount -= 1;
 
-    return command_buffer;
+    return commandBuffer;
 }
 
 static SDL_GPUCommandBuffer *VULKAN_AcquireCommandBuffer(
@@ -9578,87 +9578,87 @@ static SDL_GPUCommandBuffer *VULKAN_AcquireCommandBuffer(
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-    VulkanCommandBuffer *command_buffer =
+    VulkanCommandBuffer *commandBuffer =
         VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(renderer, threadID);
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
-    if (command_buffer == NULL) {
+    if (commandBuffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire command buffer!");
         return NULL;
     }
 
     // Reset state
 
-    command_buffer->currentComputePipeline = NULL;
-    command_buffer->currentGraphicsPipeline = NULL;
+    commandBuffer->currentComputePipeline = NULL;
+    commandBuffer->currentGraphicsPipeline = NULL;
 
     for (i = 0; i < MAX_COLOR_TARGET_BINDINGS; i += 1) {
-        command_buffer->colorAttachmentSubresources[i] = NULL;
+        commandBuffer->colorAttachmentSubresources[i] = NULL;
     }
 
     for (i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        command_buffer->vertexUniformBuffers[i] = NULL;
-        command_buffer->fragmentUniformBuffers[i] = NULL;
-        command_buffer->computeUniformBuffers[i] = NULL;
+        commandBuffer->vertexUniformBuffers[i] = NULL;
+        commandBuffer->fragmentUniformBuffers[i] = NULL;
+        commandBuffer->computeUniformBuffers[i] = NULL;
     }
 
-    command_buffer->depthStencilAttachmentSubresource = NULL;
+    commandBuffer->depthStencilAttachmentSubresource = NULL;
 
-    command_buffer->needNewVertexResourceDescriptorSet = true;
-    command_buffer->needNewVertexUniformDescriptorSet = true;
-    command_buffer->needNewVertexUniformOffsets = true;
-    command_buffer->needNewFragmentResourceDescriptorSet = true;
-    command_buffer->needNewFragmentUniformDescriptorSet = true;
-    command_buffer->needNewFragmentUniformOffsets = true;
+    commandBuffer->needNewVertexResourceDescriptorSet = true;
+    commandBuffer->needNewVertexUniformDescriptorSet = true;
+    commandBuffer->needNewVertexUniformOffsets = true;
+    commandBuffer->needNewFragmentResourceDescriptorSet = true;
+    commandBuffer->needNewFragmentUniformDescriptorSet = true;
+    commandBuffer->needNewFragmentUniformOffsets = true;
 
-    command_buffer->needNewComputeReadOnlyDescriptorSet = true;
-    command_buffer->needNewComputeUniformDescriptorSet = true;
-    command_buffer->needNewComputeUniformOffsets = true;
+    commandBuffer->needNewComputeReadOnlyDescriptorSet = true;
+    commandBuffer->needNewComputeUniformDescriptorSet = true;
+    commandBuffer->needNewComputeUniformOffsets = true;
 
-    command_buffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
 
-    command_buffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
 
-    SDL_zeroa(command_buffer->vertexSamplerTextures);
-    SDL_zeroa(command_buffer->vertexSamplers);
-    SDL_zeroa(command_buffer->vertexStorageTextures);
-    SDL_zeroa(command_buffer->vertexStorageBuffers);
+    SDL_zeroa(commandBuffer->vertexSamplerTextures);
+    SDL_zeroa(commandBuffer->vertexSamplers);
+    SDL_zeroa(commandBuffer->vertexStorageTextures);
+    SDL_zeroa(commandBuffer->vertexStorageBuffers);
 
-    SDL_zeroa(command_buffer->fragmentSamplerTextures);
-    SDL_zeroa(command_buffer->fragmentSamplers);
-    SDL_zeroa(command_buffer->fragmentStorageTextures);
-    SDL_zeroa(command_buffer->fragmentStorageBuffers);
+    SDL_zeroa(commandBuffer->fragmentSamplerTextures);
+    SDL_zeroa(commandBuffer->fragmentSamplers);
+    SDL_zeroa(commandBuffer->fragmentStorageTextures);
+    SDL_zeroa(commandBuffer->fragmentStorageBuffers);
 
-    SDL_zeroa(command_buffer->writeOnlyComputeStorageTextureSubresources);
-    command_buffer->writeOnlyComputeStorageTextureSubresourceCount = 0;
-    SDL_zeroa(command_buffer->writeOnlyComputeStorageBuffers);
-    SDL_zeroa(command_buffer->readOnlyComputeStorageTextures);
-    SDL_zeroa(command_buffer->readOnlyComputeStorageBuffers);
+    SDL_zeroa(commandBuffer->writeOnlyComputeStorageTextureSubresources);
+    commandBuffer->writeOnlyComputeStorageTextureSubresourceCount = 0;
+    SDL_zeroa(commandBuffer->writeOnlyComputeStorageBuffers);
+    SDL_zeroa(commandBuffer->readOnlyComputeStorageTextures);
+    SDL_zeroa(commandBuffer->readOnlyComputeStorageBuffers);
 
-    command_buffer->autoReleaseFence = 1;
+    commandBuffer->autoReleaseFence = 1;
 
-    command_buffer->isDefrag = 0;
+    commandBuffer->isDefrag = 0;
 
     /* Reset the command buffer here to avoid resets being called
      * from a separate thread than where the command buffer was acquired
      */
     result = renderer->vkResetCommandBuffer(
-        command_buffer->command_buffer,
+        commandBuffer->commandBuffer,
         VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT);
 
     if (result != VK_SUCCESS) {
         LogVulkanResultAsError("vkResetCommandBuffer", result);
     }
 
-    VULKAN_INTERNAL_BeginCommandBuffer(renderer, command_buffer);
+    VULKAN_INTERNAL_BeginCommandBuffer(renderer, commandBuffer);
 
-    return (SDL_GPUCommandBuffer *)command_buffer;
+    return (SDL_GPUCommandBuffer *)commandBuffer;
 }
 
 static bool VULKAN_QueryFence(
@@ -9734,7 +9734,7 @@ static SDL_bool VULKAN_INTERNAL_OnWindowResize(void *userdata, SDL_Event *e)
 static bool VULKAN_SupportsSwapchainComposition(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition)
+    SDL_GPUSwapchainComposition swapchainComposition)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
@@ -9756,16 +9756,16 @@ static bool VULKAN_SupportsSwapchainComposition(
             &supportDetails)) {
 
         result = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
-            SwapchainCompositionToFormat[swapchain_composition],
-            SwapchainCompositionToColorSpace[swapchain_composition],
+            SwapchainCompositionToFormat[swapchainComposition],
+            SwapchainCompositionToColorSpace[swapchainComposition],
             supportDetails.formats,
             supportDetails.formatsLength);
 
         if (!result) {
             // Let's try again with the fallback format...
             result = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
-                SwapchainCompositionToFallbackFormat[swapchain_composition],
-                SwapchainCompositionToColorSpace[swapchain_composition],
+                SwapchainCompositionToFallbackFormat[swapchainComposition],
+                SwapchainCompositionToColorSpace[swapchainComposition],
                 supportDetails.formats,
                 supportDetails.formatsLength);
         }
@@ -9780,7 +9780,7 @@ static bool VULKAN_SupportsSwapchainComposition(
 static bool VULKAN_SupportsPresentMode(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUPresentMode presentMode)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
@@ -9802,7 +9802,7 @@ static bool VULKAN_SupportsPresentMode(
             &supportDetails)) {
 
         result = VULKAN_INTERNAL_VerifySwapPresentMode(
-            SDLToVK_PresentMode[present_mode],
+            SDLToVK_PresentMode[presentMode],
             supportDetails.presentModes,
             supportDetails.presentModesLength);
 
@@ -9823,8 +9823,8 @@ static bool VULKAN_ClaimWindow(
     if (windowData == NULL) {
         windowData = SDL_malloc(sizeof(WindowData));
         windowData->window = window;
-        windowData->present_mode = SDL_GPU_PRESENTMODE_VSYNC;
-        windowData->swapchain_composition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
+        windowData->presentMode = SDL_GPU_PRESENTMODE_VSYNC;
+        windowData->swapchainComposition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
 
         if (VULKAN_INTERNAL_CreateSwapchain(renderer, windowData)) {
             SDL_SetPointerProperty(SDL_GetWindowProperties(window), WINDOW_PROPERTY_DATA, windowData);
@@ -9918,12 +9918,12 @@ static bool VULKAN_INTERNAL_RecreateSwapchain(
 }
 
 static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_Window *window,
     Uint32 *w,
     Uint32 *h)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     Uint32 swapchainImageIndex;
     WindowData *windowData;
@@ -9957,7 +9957,7 @@ static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
     }
 
     if (swapchainData->inFlightFences[swapchainData->frameCounter] != NULL) {
-        if (swapchainData->present_mode == VK_PRESENT_MODE_FIFO_KHR) {
+        if (swapchainData->presentMode == VK_PRESENT_MODE_FIFO_KHR) {
             // In VSYNC mode, block until the least recent presented frame is done
             VULKAN_WaitForFences(
                 (SDL_GPURenderer *)renderer,
@@ -10048,7 +10048,7 @@ static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
     imageBarrier.subresourceRange.layerCount = 1;
 
     renderer->vkCmdPipelineBarrier(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
         0,
@@ -10121,15 +10121,15 @@ static SDL_GPUTextureFormat VULKAN_GetSwapchainTextureFormat(
     }
 
     return SwapchainCompositionToSDLFormat(
-        windowData->swapchain_composition,
+        windowData->swapchainComposition,
         windowData->swapchainData->usingFallbackFormat);
 }
 
 static bool VULKAN_SetSwapchainParameters(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUSwapchainComposition swapchainComposition,
+    SDL_GPUPresentMode presentMode)
 {
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
 
@@ -10138,18 +10138,18 @@ static bool VULKAN_SetSwapchainParameters(
         return false;
     }
 
-    if (!VULKAN_SupportsSwapchainComposition(driverData, window, swapchain_composition)) {
+    if (!VULKAN_SupportsSwapchainComposition(driverData, window, swapchainComposition)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Swapchain composition not supported!");
         return false;
     }
 
-    if (!VULKAN_SupportsPresentMode(driverData, window, present_mode)) {
+    if (!VULKAN_SupportsPresentMode(driverData, window, presentMode)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Present mode not supported!");
         return false;
     }
 
-    windowData->present_mode = present_mode;
-    windowData->swapchain_composition = swapchain_composition;
+    windowData->presentMode = presentMode;
+    windowData->swapchainComposition = swapchainComposition;
 
     return VULKAN_INTERNAL_RecreateSwapchain(
         (VulkanRenderer *)driverData,
@@ -10295,23 +10295,23 @@ static void VULKAN_INTERNAL_PerformPendingDestroys(
 
 static void VULKAN_INTERNAL_CleanCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     Uint32 i;
     DescriptorSetData *descriptorSetData;
 
-    if (command_buffer->autoReleaseFence) {
+    if (commandBuffer->autoReleaseFence) {
         VULKAN_ReleaseFence(
             (SDL_GPURenderer *)renderer,
-            (SDL_GPUFence *)command_buffer->inFlightFence);
+            (SDL_GPUFence *)commandBuffer->inFlightFence);
 
-        command_buffer->inFlightFence = NULL;
+        commandBuffer->inFlightFence = NULL;
     }
 
     // Bound descriptor sets are now available
 
-    for (i = 0; i < command_buffer->boundDescriptorSetDataCount; i += 1) {
-        descriptorSetData = &command_buffer->boundDescriptorSetDatas[i];
+    for (i = 0; i < commandBuffer->boundDescriptorSetDataCount; i += 1) {
+        descriptorSetData = &commandBuffer->boundDescriptorSetDatas[i];
 
         SDL_LockMutex(descriptorSetData->descriptorSetPool->lock);
 
@@ -10328,62 +10328,62 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
         SDL_UnlockMutex(descriptorSetData->descriptorSetPool->lock);
     }
 
-    command_buffer->boundDescriptorSetDataCount = 0;
+    commandBuffer->boundDescriptorSetDataCount = 0;
 
     // Uniform buffers are now available
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
 
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
         VULKAN_INTERNAL_ReturnUniformBufferToPool(
             renderer,
-            command_buffer->usedUniformBuffers[i]);
+            commandBuffer->usedUniformBuffers[i]);
     }
-    command_buffer->usedUniformBufferCount = 0;
+    commandBuffer->usedUniformBufferCount = 0;
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
     // Decrement reference counts
 
-    for (i = 0; i < command_buffer->usedBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedBuffers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedBuffers[i]->referenceCount);
     }
-    command_buffer->usedBufferCount = 0;
+    commandBuffer->usedBufferCount = 0;
 
-    for (i = 0; i < command_buffer->usedTextureCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedTextures[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedTextureCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedTextures[i]->referenceCount);
     }
-    command_buffer->usedTextureCount = 0;
+    commandBuffer->usedTextureCount = 0;
 
-    for (i = 0; i < command_buffer->usedSamplerCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedSamplers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedSamplerCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedSamplers[i]->referenceCount);
     }
-    command_buffer->usedSamplerCount = 0;
+    commandBuffer->usedSamplerCount = 0;
 
-    for (i = 0; i < command_buffer->usedGraphicsPipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedGraphicsPipelines[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedGraphicsPipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedGraphicsPipelines[i]->referenceCount);
     }
-    command_buffer->usedGraphicsPipelineCount = 0;
+    commandBuffer->usedGraphicsPipelineCount = 0;
 
-    for (i = 0; i < command_buffer->usedComputePipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedComputePipelines[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedComputePipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedComputePipelines[i]->referenceCount);
     }
-    command_buffer->usedComputePipelineCount = 0;
+    commandBuffer->usedComputePipelineCount = 0;
 
-    for (i = 0; i < command_buffer->usedFramebufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedFramebuffers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedFramebufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedFramebuffers[i]->referenceCount);
     }
-    command_buffer->usedFramebufferCount = 0;
+    commandBuffer->usedFramebufferCount = 0;
 
     // Reset presentation data
 
-    command_buffer->presentDataCount = 0;
-    command_buffer->waitSemaphoreCount = 0;
-    command_buffer->signalSemaphoreCount = 0;
+    commandBuffer->presentDataCount = 0;
+    commandBuffer->waitSemaphoreCount = 0;
+    commandBuffer->signalSemaphoreCount = 0;
 
     // Reset defrag state
 
-    if (command_buffer->isDefrag) {
+    if (commandBuffer->isDefrag) {
         renderer->defragInProgress = 0;
     }
 
@@ -10391,21 +10391,21 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-    if (command_buffer->commandPool->inactiveCommandBufferCount == command_buffer->commandPool->inactiveCommandBufferCapacity) {
-        command_buffer->commandPool->inactiveCommandBufferCapacity += 1;
-        command_buffer->commandPool->inactiveCommandBuffers = SDL_realloc(
-            command_buffer->commandPool->inactiveCommandBuffers,
-            command_buffer->commandPool->inactiveCommandBufferCapacity * sizeof(VulkanCommandBuffer *));
+    if (commandBuffer->commandPool->inactiveCommandBufferCount == commandBuffer->commandPool->inactiveCommandBufferCapacity) {
+        commandBuffer->commandPool->inactiveCommandBufferCapacity += 1;
+        commandBuffer->commandPool->inactiveCommandBuffers = SDL_realloc(
+            commandBuffer->commandPool->inactiveCommandBuffers,
+            commandBuffer->commandPool->inactiveCommandBufferCapacity * sizeof(VulkanCommandBuffer *));
     }
 
-    command_buffer->commandPool->inactiveCommandBuffers[command_buffer->commandPool->inactiveCommandBufferCount] = command_buffer;
-    command_buffer->commandPool->inactiveCommandBufferCount += 1;
+    commandBuffer->commandPool->inactiveCommandBuffers[commandBuffer->commandPool->inactiveCommandBufferCount] = commandBuffer;
+    commandBuffer->commandPool->inactiveCommandBufferCount += 1;
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
     // Remove this command buffer from the submitted list
     for (i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-        if (renderer->submittedCommandBuffers[i] == command_buffer) {
+        if (renderer->submittedCommandBuffers[i] == commandBuffer) {
             renderer->submittedCommandBuffers[i] = renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount - 1];
             renderer->submittedCommandBufferCount -= 1;
         }
@@ -10414,23 +10414,23 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
 
 static void VULKAN_WaitForFences(
     SDL_GPURenderer *driverData,
-    bool wait_all,
+    bool waitAll,
     SDL_GPUFence *const *fences,
-    Uint32 num_fences)
+    Uint32 numFences)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VkFence *vkFences = SDL_stack_alloc(VkFence, num_fences);
+    VkFence *vkFences = SDL_stack_alloc(VkFence, numFences);
     VkResult result;
 
-    for (Uint32 i = 0; i < num_fences; i += 1) {
+    for (Uint32 i = 0; i < numFences; i += 1) {
         vkFences[i] = ((VulkanFenceHandle *)fences[i])->fence;
     }
 
     result = renderer->vkWaitForFences(
         renderer->logicalDevice,
-        num_fences,
+        numFences,
         vkFences,
-        wait_all,
+        waitAll,
         UINT64_MAX);
 
     if (result != VK_SUCCESS) {
@@ -10462,7 +10462,7 @@ static void VULKAN_Wait(
     SDL_GPURenderer *driverData)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
     VkResult result;
     Sint32 i;
 
@@ -10476,8 +10476,8 @@ static void VULKAN_Wait(
     SDL_LockMutex(renderer->submitLock);
 
     for (i = renderer->submittedCommandBufferCount - 1; i >= 0; i -= 1) {
-        command_buffer = renderer->submittedCommandBuffers[i];
-        VULKAN_INTERNAL_CleanCommandBuffer(renderer, command_buffer);
+        commandBuffer = renderer->submittedCommandBuffers[i];
+        VULKAN_INTERNAL_CleanCommandBuffer(renderer, commandBuffer);
     }
 
     VULKAN_INTERNAL_PerformPendingDestroys(renderer);
@@ -10486,22 +10486,22 @@ static void VULKAN_Wait(
 }
 
 static SDL_GPUFence *VULKAN_SubmitAndAcquireFence(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     VulkanCommandBuffer *vulkanCommandBuffer;
 
-    vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     vulkanCommandBuffer->autoReleaseFence = 0;
 
-    VULKAN_Submit(command_buffer);
+    VULKAN_Submit(commandBuffer);
 
     return (SDL_GPUFence *)vulkanCommandBuffer->inFlightFence;
 }
 
 static void VULKAN_Submit(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkSubmitInfo submitInfo;
     VkPresentInfoKHR presentInfo;
@@ -10545,7 +10545,7 @@ static void VULKAN_Submit(
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submitInfo.pNext = NULL;
     submitInfo.commandBufferCount = 1;
-    submitInfo.pCommandBuffers = &vulkanCommandBuffer->command_buffer;
+    submitInfo.pCommandBuffers = &vulkanCommandBuffer->commandBuffer;
 
     submitInfo.pWaitDstStageMask = waitStages;
     submitInfo.pWaitSemaphores = vulkanCommandBuffer->waitSemaphores;
@@ -10670,7 +10670,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
     VulkanTexture *newTexture;
     VkBufferCopy bufferCopy;
     VkImageCopy imageCopy;
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
     VulkanTextureSubresource *srcSubresource;
     VulkanTextureSubresource *dstSubresource;
     Uint32 i, subresourceIndex;
@@ -10679,12 +10679,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
     renderer->defragInProgress = 1;
 
-    command_buffer = (VulkanCommandBuffer *)VULKAN_AcquireCommandBuffer((SDL_GPURenderer *)renderer);
-    if (command_buffer == NULL) {
+    commandBuffer = (VulkanCommandBuffer *)VULKAN_AcquireCommandBuffer((SDL_GPURenderer *)renderer);
+    if (commandBuffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create defrag command buffer!");
         return 0;
     }
-    command_buffer->isDefrag = 1;
+    commandBuffer->isDefrag = 1;
 
     allocation = renderer->allocationsToDefrag[renderer->allocationsToDefragCount - 1];
     renderer->allocationsToDefragCount -= 1;
@@ -10697,12 +10697,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
         currentRegion = allocation->usedRegions[i];
 
         if (currentRegion->isBuffer && !currentRegion->vulkanBuffer->markedForDestroy) {
-            currentRegion->vulkanBuffer->usage_flags |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+            currentRegion->vulkanBuffer->usageFlags |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
             newBuffer = VULKAN_INTERNAL_CreateBuffer(
                 renderer,
                 currentRegion->vulkanBuffer->size,
-                currentRegion->vulkanBuffer->usage_flags,
+                currentRegion->vulkanBuffer->usageFlags,
                 currentRegion->vulkanBuffer->type);
 
             if (newBuffer == NULL) {
@@ -10711,7 +10711,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
             }
 
             if (
-                renderer->debug_mode &&
+                renderer->debugMode &&
                 renderer->supportsDebugUtils &&
                 currentRegion->vulkanBuffer->handle != NULL &&
                 currentRegion->vulkanBuffer->handle->container != NULL &&
@@ -10727,13 +10727,13 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 currentRegion->vulkanBuffer->type == VULKAN_BUFFER_TYPE_GPU && currentRegion->vulkanBuffer->transitioned) {
                 VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
                     renderer,
-                    command_buffer,
+                    commandBuffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_SOURCE,
                     currentRegion->vulkanBuffer);
 
                 VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
                     renderer,
-                    command_buffer,
+                    commandBuffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_DESTINATION,
                     newBuffer);
 
@@ -10742,7 +10742,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 bufferCopy.size = currentRegion->resourceSize;
 
                 renderer->vkCmdCopyBuffer(
-                    command_buffer->command_buffer,
+                    commandBuffer->commandBuffer,
                     currentRegion->vulkanBuffer->buffer,
                     newBuffer->buffer,
                     1,
@@ -10750,12 +10750,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                 VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
                     renderer,
-                    command_buffer,
+                    commandBuffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_DESTINATION,
                     newBuffer);
 
-                VULKAN_INTERNAL_TrackBuffer(command_buffer, currentRegion->vulkanBuffer);
-                VULKAN_INTERNAL_TrackBuffer(command_buffer, newBuffer);
+                VULKAN_INTERNAL_TrackBuffer(commandBuffer, currentRegion->vulkanBuffer);
+                VULKAN_INTERNAL_TrackBuffer(commandBuffer, newBuffer);
             }
 
             // re-point original container to new buffer
@@ -10774,12 +10774,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 currentRegion->vulkanTexture->depth,
                 currentRegion->vulkanTexture->type,
                 currentRegion->vulkanTexture->layerCount,
-                currentRegion->vulkanTexture->num_levels,
-                currentRegion->vulkanTexture->sample_count,
+                currentRegion->vulkanTexture->numLevels,
+                currentRegion->vulkanTexture->sampleCount,
                 currentRegion->vulkanTexture->format,
                 currentRegion->vulkanTexture->swizzle,
                 currentRegion->vulkanTexture->aspectFlags,
-                currentRegion->vulkanTexture->usage_flags,
+                currentRegion->vulkanTexture->usageFlags,
                 currentRegion->vulkanTexture->isMSAAColorTarget);
 
             if (newTexture == NULL) {
@@ -10794,7 +10794,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                 // Set debug name if it exists
                 if (
-                    renderer->debug_mode &&
+                    renderer->debugMode &&
                     renderer->supportsDebugUtils &&
                     srcSubresource->parent->handle != NULL &&
                     srcSubresource->parent->handle->container != NULL &&
@@ -10808,13 +10808,13 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 if (srcSubresource->transitioned) {
                     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
                         renderer,
-                        command_buffer,
+                        commandBuffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_SOURCE,
                         srcSubresource);
 
                     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
                         renderer,
-                        command_buffer,
+                        commandBuffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION,
                         dstSubresource);
 
@@ -10837,7 +10837,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                     imageCopy.dstSubresource.mipLevel = dstSubresource->level;
 
                     renderer->vkCmdCopyImage(
-                        command_buffer->command_buffer,
+                        commandBuffer->commandBuffer,
                         currentRegion->vulkanTexture->image,
                         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                         newTexture->image,
@@ -10847,12 +10847,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                     VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
                         renderer,
-                        command_buffer,
+                        commandBuffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION,
                         dstSubresource);
 
-                    VULKAN_INTERNAL_TrackTexture(command_buffer, srcSubresource->parent);
-                    VULKAN_INTERNAL_TrackTexture(command_buffer, dstSubresource->parent);
+                    VULKAN_INTERNAL_TrackTexture(commandBuffer, srcSubresource->parent);
+                    VULKAN_INTERNAL_TrackTexture(commandBuffer, dstSubresource->parent);
                 }
             }
 
@@ -10868,7 +10868,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
     SDL_UnlockMutex(renderer->allocatorLock);
 
     VULKAN_Submit(
-        (SDL_GPUCommandBuffer *)command_buffer);
+        (SDL_GPUCommandBuffer *)commandBuffer);
 
     return 1;
 }
@@ -11185,7 +11185,7 @@ static Uint8 VULKAN_INTERNAL_CreateInstance(VulkanRenderer *renderer)
     createInfo.ppEnabledLayerNames = layerNames;
     createInfo.enabledExtensionCount = instanceExtensionCount;
     createInfo.ppEnabledExtensionNames = instanceExtensionNames;
-    if (renderer->debug_mode) {
+    if (renderer->debugMode) {
         createInfo.enabledLayerCount = SDL_arraysize(layerNames);
         if (!VULKAN_INTERNAL_CheckValidationLayers(
                 layerNames,
@@ -11623,13 +11623,13 @@ static bool VULKAN_INTERNAL_PrepareVulkan(
     return true;
 }
 
-static bool VULKAN_PrepareDriver(SDL_VideoDevice *_this)
+static bool VULKAN_PrepareDriver(SDL_VideoDevice *this)
 {
     // Set up dummy VulkanRenderer
     VulkanRenderer *renderer;
     Uint8 result;
 
-    if (_this->Vulkan_CreateSurface == NULL) {
+    if (this->Vulkan_CreateSurface == NULL) {
         return false;
     }
 
@@ -11650,7 +11650,7 @@ static bool VULKAN_PrepareDriver(SDL_VideoDevice *_this)
     return result;
 }
 
-static SDL_GPUDevice *VULKAN_CreateDevice(bool debug_mode, bool preferLowPower, SDL_PropertiesID props)
+static SDL_GPUDevice *VULKAN_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
 {
     VulkanRenderer *renderer;
 
@@ -11668,7 +11668,7 @@ static SDL_GPUDevice *VULKAN_CreateDevice(bool debug_mode, bool preferLowPower, 
 
     renderer = (VulkanRenderer *)SDL_malloc(sizeof(VulkanRenderer));
     SDL_memset(renderer, '\0', sizeof(VulkanRenderer));
-    renderer->debug_mode = debug_mode;
+    renderer->debugMode = debugMode;
     renderer->preferLowPower = preferLowPower;
 
     if (!VULKAN_INTERNAL_PrepareVulkan(renderer)) {

--- a/src/render/sdlgpu/SDL_pipeline_gpu.c
+++ b/src/render/sdlgpu/SDL_pipeline_gpu.c
@@ -124,7 +124,7 @@ static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders 
 
     pci.rasterizer_state.cull_mode = SDL_GPU_CULLMODE_NONE;
     pci.rasterizer_state.fill_mode = SDL_GPU_FILLMODE_FILL;
-    pci.rasterizer_state.frontFace = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE;
+    pci.rasterizer_state.front_face = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE;
 
     SDL_GPUVertexBinding bind;
     SDL_zero(bind);

--- a/src/render/sdlgpu/SDL_pipeline_gpu.c
+++ b/src/render/sdlgpu/SDL_pipeline_gpu.c
@@ -97,7 +97,7 @@ void GPU_DestroyPipelineCache(GPU_PipelineCache *cache)
 
 static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders *shaders, const GPU_PipelineParameters *params)
 {
-    SDL_GPUColorAttachmentDescription ad;
+    SDL_GPUColorTargetDescription ad;
     SDL_zero(ad);
     ad.format = params->attachment_format;
 
@@ -113,9 +113,9 @@ static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders 
 
     SDL_GPUGraphicsPipelineCreateInfo pci;
     SDL_zero(pci);
-    pci.attachment_info.has_depth_stencil_attachment = false;
-    pci.attachment_info.num_color_attachments = 1;
-    pci.attachment_info.color_attachment_descriptions = &ad;
+    pci.target_info.has_depth_stencil_target = false;
+    pci.target_info.num_color_targets = 1;
+    pci.target_info.color_target_descriptions = &ad;
     pci.vertex_shader = GPU_GetVertexShader(shaders, params->vert_shader);
     pci.fragment_shader = GPU_GetFragmentShader(shaders, params->frag_shader);
     pci.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;

--- a/src/render/sdlgpu/SDL_render_gpu.c
+++ b/src/render/sdlgpu/SDL_render_gpu.c
@@ -69,7 +69,7 @@ typedef struct GPU_RenderData
         SDL_GPURenderPass *render_pass;
         SDL_Texture *render_target;
         SDL_GPUCommandBuffer *command_buffer;
-        SDL_GPUColorAttachmentInfo color_attachment;
+        SDL_GPUColorTargetInfo color_attachment;
         SDL_GPUViewport viewport;
         SDL_Rect scissor;
         SDL_FColor draw_color;

--- a/src/render/sdlgpu/SDL_render_gpu.c
+++ b/src/render/sdlgpu/SDL_render_gpu.c
@@ -221,7 +221,7 @@ static bool GPU_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_
     tci.format = format;
     tci.layer_count_or_depth = 1;
     tci.num_levels = 1;
-    tci.usage_flags = usage;
+    tci.usage = usage;
     tci.width = texture->w;
     tci.height = texture->h;
     tci.sample_count = SDL_GPU_SAMPLECOUNT_1;
@@ -608,7 +608,7 @@ static bool InitVertexBuffer(GPU_RenderData *data, Uint32 size)
     SDL_GPUBufferCreateInfo bci;
     SDL_zero(bci);
     bci.size = size;
-    bci.usage_flags = SDL_GPU_BUFFERUSAGE_VERTEX;
+    bci.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
 
     data->vertices.buffer = SDL_CreateGPUBuffer(data->device, &bci);
 
@@ -928,7 +928,7 @@ static bool CreateBackbuffer(GPU_RenderData *data, Uint32 w, Uint32 h, SDL_GPUTe
     tci.layer_count_or_depth = 1;
     tci.num_levels = 1;
     tci.sample_count = SDL_GPU_SAMPLECOUNT_1;
-    tci.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
+    tci.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
 
     data->backbuffer.texture = SDL_CreateGPUTexture(data->device, &tci);
     data->backbuffer.width = w;
@@ -1272,8 +1272,8 @@ static bool GPU_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
     data->state.draw_color.g = 1.0f;
     data->state.draw_color.b = 1.0f;
     data->state.draw_color.a = 1.0f;
-    data->state.viewport.minDepth = 0;
-    data->state.viewport.maxDepth = 1;
+    data->state.viewport.min_depth = 0;
+    data->state.viewport.max_depth = 1;
     data->state.command_buffer = SDL_AcquireGPUCommandBuffer(data->device);
 
     int w, h;

--- a/src/render/sdlgpu/SDL_shaders_gpu.c
+++ b/src/render/sdlgpu/SDL_shaders_gpu.c
@@ -170,7 +170,7 @@ static SDL_GPUShader *CompileShader(const GPU_ShaderSources *sources, SDL_GPUDev
     sci.code_size = sms->code_len;
     sci.format = sms->format;
     // FIXME not sure if this is correct
-    sci.entrypoint_name = driver == SDL_GPU_DRIVER_METAL ? "main0" : "main";
+    sci.entrypoint = driver == SDL_GPU_DRIVER_METAL ? "main0" : "main";
     sci.num_samplers = sources->num_samplers;
     sci.num_uniform_buffers = sources->num_uniform_buffers;
     sci.stage = stage;

--- a/test/testgpu_simple_clear.c
+++ b/test/testgpu_simple_clear.c
@@ -89,17 +89,17 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 	if (swapchainTexture != NULL) {
         const double currentTime = (double)SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency();
         SDL_GPURenderPass *renderPass;
-		SDL_GPUColorTargetInfo colorAttachmentInfo;
-        SDL_zero(colorAttachmentInfo);
-		colorAttachmentInfo.texture = swapchainTexture;
-		colorAttachmentInfo.clear_color.r = (float)(0.5 + 0.5 * SDL_sin(currentTime));
-		colorAttachmentInfo.clear_color.g = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 2 / 3));
-		colorAttachmentInfo.clear_color.b = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 4 / 3));;
-		colorAttachmentInfo.clear_color.a = 1.0f;
-		colorAttachmentInfo.load_op = SDL_GPU_LOADOP_CLEAR;
-		colorAttachmentInfo.store_op = SDL_GPU_STOREOP_STORE;
+		SDL_GPUColorTargetInfo color_target_info;
+        SDL_zero(color_target_info);
+		color_target_info.texture = swapchainTexture;
+		color_target_info.clear_color.r = (float)(0.5 + 0.5 * SDL_sin(currentTime));
+		color_target_info.clear_color.g = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 2 / 3));
+		color_target_info.clear_color.b = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 4 / 3));;
+		color_target_info.clear_color.a = 1.0f;
+		color_target_info.load_op = SDL_GPU_LOADOP_CLEAR;
+		color_target_info.store_op = SDL_GPU_STOREOP_STORE;
 
-		renderPass = SDL_BeginGPURenderPass(cmdbuf, &colorAttachmentInfo, 1, NULL);
+		renderPass = SDL_BeginGPURenderPass(cmdbuf, &color_target_info, 1, NULL);
 		SDL_EndGPURenderPass(renderPass);
 	}
 

--- a/test/testgpu_simple_clear.c
+++ b/test/testgpu_simple_clear.c
@@ -89,7 +89,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 	if (swapchainTexture != NULL) {
         const double currentTime = (double)SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency();
         SDL_GPURenderPass *renderPass;
-		SDL_GPUColorAttachmentInfo colorAttachmentInfo;
+		SDL_GPUColorTargetInfo colorAttachmentInfo;
         SDL_zero(colorAttachmentInfo);
 		colorAttachmentInfo.texture = swapchainTexture;
 		colorAttachmentInfo.clear_color.r = (float)(0.5 + 0.5 * SDL_sin(currentTime));
@@ -122,4 +122,3 @@ void SDL_AppQuit(void *appstate)
 	SDL_DestroyGPUDevice(gpu_device);
     SDLTest_CommonQuit(state);
 }
-

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -299,8 +299,8 @@ Render(SDL_Window *window, const int windownum)
 {
     WindowState *winstate = &window_states[windownum];
     SDL_GPUTexture *swapchain;
-    SDL_GPUColorAttachmentInfo color_attachment;
-    SDL_GPUDepthStencilAttachmentInfo depth_attachment;
+    SDL_GPUColorTargetInfo color_attachment;
+    SDL_GPUDepthStencilTargetInfo depth_attachment;
     float matrix_rotate[16], matrix_modelview[16], matrix_perspective[16], matrix_final[16];
     Uint32 drawablew, drawableh;
     SDL_GPUCommandBuffer *cmd;
@@ -459,7 +459,7 @@ init_render_state(int msaa)
     SDL_GPUBufferCreateInfo buffer_desc;
     SDL_GPUTransferBufferCreateInfo transfer_buffer_desc;
     SDL_GPUGraphicsPipelineCreateInfo pipelinedesc;
-    SDL_GPUColorAttachmentDescription color_attachment_desc;
+    SDL_GPUColorTargetDescription color_attachment_desc;
     Uint32 drawablew, drawableh;
     SDL_GPUVertexAttribute vertex_attributes[2];
     SDL_GPUVertexBinding vertex_binding;
@@ -554,10 +554,10 @@ init_render_state(int msaa)
     color_attachment_desc.blend_state.src_color_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
     color_attachment_desc.blend_state.dst_color_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
 
-    pipelinedesc.attachment_info.num_color_attachments = 1;
-    pipelinedesc.attachment_info.color_attachment_descriptions = &color_attachment_desc;
-    pipelinedesc.attachment_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM;
-    pipelinedesc.attachment_info.has_depth_stencil_attachment = SDL_TRUE;
+    pipelinedesc.target_info.num_color_targets = 1;
+    pipelinedesc.target_info.color_target_descriptions = &color_attachment_desc;
+    pipelinedesc.target_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM;
+    pipelinedesc.target_info.has_depth_stencil_target = SDL_TRUE;
 
     pipelinedesc.depth_stencil_state.enable_depth_test = 1;
     pipelinedesc.depth_stencil_state.enable_depth_write = 1;

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -259,7 +259,7 @@ CreateDepthTexture(Uint32 drawablew, Uint32 drawableh)
     depthtex_createinfo.layer_count_or_depth = 1;
     depthtex_createinfo.num_levels = 1;
     depthtex_createinfo.sample_count = render_state.sample_count;
-    depthtex_createinfo.usage_flags = SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
+    depthtex_createinfo.usage = SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
     depthtex_createinfo.props = 0;
 
     result = SDL_CreateGPUTexture(gpu_device, &depthtex_createinfo);
@@ -285,7 +285,7 @@ CreateMSAATexture(Uint32 drawablew, Uint32 drawableh)
     msaatex_createinfo.layer_count_or_depth = 1;
     msaatex_createinfo.num_levels = 1;
     msaatex_createinfo.sample_count = render_state.sample_count;
-    msaatex_createinfo.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
+    msaatex_createinfo.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
     msaatex_createinfo.props = 0;
 
     result = SDL_CreateGPUTexture(gpu_device, &msaatex_createinfo);
@@ -425,22 +425,22 @@ load_shader(SDL_bool is_vertex)
         createinfo.format = SDL_GPU_SHADERFORMAT_DXBC;
         createinfo.code = is_vertex ? D3D11_CubeVert : D3D11_CubeFrag;
         createinfo.code_size = is_vertex ? SDL_arraysize(D3D11_CubeVert) : SDL_arraysize(D3D11_CubeFrag);
-        createinfo.entrypoint_name = is_vertex ? "VSMain" : "PSMain";
+        createinfo.entrypoint = is_vertex ? "VSMain" : "PSMain";
     } else if (backend == SDL_GPU_DRIVER_D3D12) {
         createinfo.format = SDL_GPU_SHADERFORMAT_DXIL;
         createinfo.code = is_vertex ? D3D12_CubeVert : D3D12_CubeFrag;
         createinfo.code_size = is_vertex ? SDL_arraysize(D3D12_CubeVert) : SDL_arraysize(D3D12_CubeFrag);
-        createinfo.entrypoint_name = is_vertex ? "VSMain" : "PSMain";
+        createinfo.entrypoint = is_vertex ? "VSMain" : "PSMain";
     } else if (backend == SDL_GPU_DRIVER_METAL) {
         createinfo.format = SDL_GPU_SHADERFORMAT_METALLIB;
         createinfo.code = is_vertex ? cube_vert_metallib : cube_frag_metallib;
         createinfo.code_size = is_vertex ? cube_vert_metallib_len : cube_frag_metallib_len;
-        createinfo.entrypoint_name = is_vertex ? "vs_main" : "fs_main";
+        createinfo.entrypoint = is_vertex ? "vs_main" : "fs_main";
     } else {
         createinfo.format = SDL_GPU_SHADERFORMAT_SPIRV;
         createinfo.code = is_vertex ? cube_vert_spv : cube_frag_spv;
         createinfo.code_size = is_vertex ? cube_vert_spv_len : cube_frag_spv_len;
-        createinfo.entrypoint_name = "main";
+        createinfo.entrypoint = "main";
     }
 
     createinfo.stage = is_vertex ? SDL_GPU_SHADERSTAGE_VERTEX : SDL_GPU_SHADERSTAGE_FRAGMENT;
@@ -492,7 +492,7 @@ init_render_state(int msaa)
 
     /* Create buffers */
 
-    buffer_desc.usage_flags = SDL_GPU_BUFFERUSAGE_VERTEX;
+    buffer_desc.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
     buffer_desc.size = sizeof(vertex_data);
     buffer_desc.props = 0;
     render_state.buf_vertex = SDL_CreateGPUBuffer(

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -299,8 +299,8 @@ Render(SDL_Window *window, const int windownum)
 {
     WindowState *winstate = &window_states[windownum];
     SDL_GPUTexture *swapchain;
-    SDL_GPUColorTargetInfo color_attachment;
-    SDL_GPUDepthStencilTargetInfo depth_attachment;
+    SDL_GPUColorTargetInfo color_target;
+    SDL_GPUDepthStencilTargetInfo depth_target;
     float matrix_rotate[16], matrix_modelview[16], matrix_perspective[16], matrix_final[16];
     Uint32 drawablew, drawableh;
     SDL_GPUCommandBuffer *cmd;
@@ -363,18 +363,18 @@ Render(SDL_Window *window, const int windownum)
 
     /* Set up the pass */
 
-    SDL_zero(color_attachment);
-    color_attachment.clear_color.a = 1.0f;
-    color_attachment.load_op = SDL_GPU_LOADOP_CLEAR;
-    color_attachment.store_op = SDL_GPU_STOREOP_STORE;
-    color_attachment.texture = winstate->tex_msaa ? winstate->tex_msaa : swapchain;
+    SDL_zero(color_target);
+    color_target.clear_color.a = 1.0f;
+    color_target.load_op = SDL_GPU_LOADOP_CLEAR;
+    color_target.store_op = SDL_GPU_STOREOP_STORE;
+    color_target.texture = winstate->tex_msaa ? winstate->tex_msaa : swapchain;
 
-    SDL_zero(depth_attachment);
-    depth_attachment.clear_value.depth = 1.0f;
-    depth_attachment.load_op = SDL_GPU_LOADOP_CLEAR;
-    depth_attachment.store_op = SDL_GPU_STOREOP_DONT_CARE;
-    depth_attachment.texture = winstate->tex_depth;
-    depth_attachment.cycle = SDL_TRUE;
+    SDL_zero(depth_target);
+    depth_target.clear_value.depth = 1.0f;
+    depth_target.load_op = SDL_GPU_LOADOP_CLEAR;
+    depth_target.store_op = SDL_GPU_STOREOP_DONT_CARE;
+    depth_target.texture = winstate->tex_depth;
+    depth_target.cycle = SDL_TRUE;
 
     /* Set up the bindings */
 
@@ -385,7 +385,7 @@ Render(SDL_Window *window, const int windownum)
 
     SDL_PushGPUVertexUniformData(cmd, 0, matrix_final, sizeof(matrix_final));
 
-    pass = SDL_BeginGPURenderPass(cmd, &color_attachment, 1, &depth_attachment);
+    pass = SDL_BeginGPURenderPass(cmd, &color_target, 1, &depth_target);
     SDL_BindGPUGraphicsPipeline(pass, render_state.pipeline);
     SDL_BindGPUVertexBuffers(pass, 0, &vertex_binding, 1);
     SDL_DrawGPUPrimitives(pass, 36, 1, 0, 0);
@@ -459,7 +459,7 @@ init_render_state(int msaa)
     SDL_GPUBufferCreateInfo buffer_desc;
     SDL_GPUTransferBufferCreateInfo transfer_buffer_desc;
     SDL_GPUGraphicsPipelineCreateInfo pipelinedesc;
-    SDL_GPUColorTargetDescription color_attachment_desc;
+    SDL_GPUColorTargetDescription color_target_desc;
     Uint32 drawablew, drawableh;
     SDL_GPUVertexAttribute vertex_attributes[2];
     SDL_GPUVertexBinding vertex_binding;
@@ -543,19 +543,19 @@ init_render_state(int msaa)
 
     SDL_zero(pipelinedesc);
 
-    color_attachment_desc.format = SDL_GetGPUSwapchainTextureFormat(gpu_device, state->windows[0]);
+    color_target_desc.format = SDL_GetGPUSwapchainTextureFormat(gpu_device, state->windows[0]);
 
-    color_attachment_desc.blend_state.enable_blend = 0;
-    color_attachment_desc.blend_state.alpha_blend_op = SDL_GPU_BLENDOP_ADD;
-    color_attachment_desc.blend_state.color_blend_op = SDL_GPU_BLENDOP_ADD;
-    color_attachment_desc.blend_state.color_write_mask = 0xF;
-    color_attachment_desc.blend_state.src_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
-    color_attachment_desc.blend_state.dst_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
-    color_attachment_desc.blend_state.src_color_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
-    color_attachment_desc.blend_state.dst_color_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
+    color_target_desc.blend_state.enable_blend = 0;
+    color_target_desc.blend_state.alpha_blend_op = SDL_GPU_BLENDOP_ADD;
+    color_target_desc.blend_state.color_blend_op = SDL_GPU_BLENDOP_ADD;
+    color_target_desc.blend_state.color_write_mask = 0xF;
+    color_target_desc.blend_state.src_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
+    color_target_desc.blend_state.dst_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
+    color_target_desc.blend_state.src_color_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
+    color_target_desc.blend_state.dst_color_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
 
     pipelinedesc.target_info.num_color_targets = 1;
-    pipelinedesc.target_info.color_target_descriptions = &color_attachment_desc;
+    pipelinedesc.target_info.color_target_descriptions = &color_target_desc;
     pipelinedesc.target_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM;
     pipelinedesc.target_info.has_depth_stencil_target = SDL_TRUE;
 


### PR DESCRIPTION
Here are the conventions I tried to follow:

- snake_case for variables and fields in gpu.h or gpu.c
- camelBack for variables and fields in backend implementations and sysgpu.h

